### PR TITLE
Add --classNames option to test command

### DIFF
--- a/lib/cli/test.js
+++ b/lib/cli/test.js
@@ -1,21 +1,198 @@
 "use strict";
 
-var DeployCommand = require('./deploy');
+var path = require('path');
+var archiver = require('archiver');
+var chalk = require('chalk');
+var Command = require('./command');
+var config = new(require('../config'))();
+var Manifest = require('../manifest');
+var CliUtils = require('./utils');
+var formatting = require('../test-result-formatting');
 
 var doc = "Usage:\n" +
-	"	force-dev-tool test [<remote>]";
+	"	force-dev-tool test [options] [<remote>]\n" +
+	"\n" +
+	"Options:\n" +
+	"	--classNames=<classNames>    Names of Test Classes. Supported API versions =< 36.0\n" +
+	"	--apiVersion=<apiVersion>    API version.\n" +
+	"	--verbose                    Print log messages for successful test methods.\n" +
+	"	-d=<directory>               Directory containing the metadata and package.xml.";
 
-var Subcommand = module.exports = function(project) {
-	var self = this;
-	DeployCommand.call(self, project, doc);
-	self.action = "Test execution";
-	self.opts = self.docopt();
-	self.deployOpts = {
+var printStartingMessage = function(remote) {
+	console.log('Running Test execution to remote ' + chalk.cyan(remote.name));
+};
+
+var logToConsole = function(messages) {
+	return console.log(messages.join('\n'));
+};
+
+var login = function(remote, onSuccess, onError) {
+	return remote.connect(function(loginErr, conn) {
+		if (loginErr) {
+			return onError('Login failed for remote ' + remote.name + ': ' + loginErr);
+		}
+		return onSuccess(conn);
+	});
+};
+
+var runTestsSynchronous = function(connection, classNames, verbose, callback) {
+	var conn = connection;
+
+	return conn.tooling.runTestsSynchronous(classNames, function(err, res) {
+		if (err) {
+			return callback(err);
+		}
+
+		var overview = formatting.formatOverview(res);
+		var messages = [];
+
+		if (verbose) {
+			messages = messages.concat(formatting.formatSuccesses(res));
+		}
+
+		messages = messages.concat(formatting.formatFailures(res));
+
+		logToConsole(messages);
+
+		if (res['failures'].length > 0) {
+			return callback(new Error(overview));
+		}
+
+		return callback(null, overview);
+	});
+};
+
+var testClassNames = function(command, classNames, callback) {
+	command.opts = command.opts ? command.opts : command.docopt();
+
+	var config = new(require('../config'))();
+	// see https://github.com/jsforce/jsforce/issues/493
+	var apiVersion = command.opts['--apiVersion'] || '36.0'
+	config.set('defaultApiVersion', apiVersion);
+
+	var remote;
+	try {
+		remote = command.project.remotes.get(command.opts['<remote>']);
+	} catch (err) {
+		return callback(err);
+	}
+
+	printStartingMessage(remote);
+
+	var verbose = command.opts['--verbose'] ? true : false
+	var whenLoggedIn = function(conn) {
+		return runTestsSynchronous(conn, classNames, verbose, callback);
+	};
+	var onLoginError = function(errMessage) {
+		return callback(errMessage);
+	};
+
+	return login(remote, whenLoggedIn, onLoginError);
+};
+
+var printTestAllResults = function(res, verbose) {
+	var deployDetails = res.details;
+	var runTestResult = deployDetails.runTestResult;
+	var messages = [];
+
+	if (verbose) {
+		messages = messages.concat(formatting.formatSuccesses(runTestResult));
+	}
+
+	messages = messages.concat(formatting.formatFailures(runTestResult));
+	messages = messages.concat(formatting.formatComponentFailures(deployDetails));
+	messages = messages.concat(formatting.formatCodeCoverageWarnings(runTestResult));
+
+	return logToConsole(messages);
+}
+
+var deployEmptyCheckOnly = function(connection, archive, verbose, callback) {
+	var conn = connection;
+	var deployOpts = {
 		rollbackOnError: true,
 		checkOnly: true,
 		testLevel: 'RunLocalTests'
 	};
+	var messages = [];
+
+	conn.metadata.pollTimeout = config.pollTimeout;
+
+	return conn.metadata.deploy(archive, deployOpts).complete({
+		details: true
+	}, function(err, res) {
+		if (err) {
+			return callback(err);
+		}
+
+		printTestAllResults(res, verbose);
+
+		if (res.id) {
+			messages.push('Visit ' + conn.instanceUrl + '/changemgmt/monitorDeploymentsDetails.apexp?asyncId=' + res.id + ' for more information.');
+		}
+
+		if (res.details && res.details.runTestResult) {
+			messages.push(formatting.formatOverview(res.details.runTestResult));
+		}
+
+		if (res.status === 'Failed') {
+			return callback(messages.join("\n"));
+		}
+
+		return callback(null, messages.join("\n"));
+	});
 };
 
-Subcommand.prototype = Object.create(DeployCommand.prototype);
-Subcommand.prototype.constructor = Subcommand;
+var testAll = function(command, callback) {
+	var remote;
+	var verbose = command.opts['--verbose'] ? true : false
+
+	try {
+		remote = command.project.remotes.get(command.opts['<remote>']);
+	} catch (err) {
+		return callback(err);
+	}
+
+	command.archive = archiver('zip', {});
+	var deployRoot = command.opts['-d'] ? path.resolve(command.opts['-d']) : command.project.storage.getSrcPath();
+	var currentPackageXml = new Manifest();
+	try {
+		currentPackageXml = Manifest.fromPackageXml(CliUtils.readFileSafe(path.join(deployRoot, 'package.xml')));
+		config.set('defaultApiVersion', currentPackageXml.apiVersion);
+	} catch (err) {
+		// ignore since running unit tests using an empty deployment does not require a package.xml
+	}
+
+	printStartingMessage(remote);
+
+	command.archive.finalize();
+
+	var whenLoggedIn = function(conn) {
+		return deployEmptyCheckOnly(conn, command.archive, verbose, callback);
+	};
+
+	var onLoginError = function(errMessage) {
+		return callback(errMessage);
+	};
+
+	return login(remote, whenLoggedIn, onLoginError);
+};
+
+var SubCommand = module.exports = function(project) {
+	Command.call(this, doc, project);
+};
+
+SubCommand.prototype = Object.create(Command.prototype);
+SubCommand.prototype.constructor = SubCommand;
+
+SubCommand.prototype.process = function(proc, callback) {
+	var command = this;
+	command.opts = command.opts ? command.opts : command.docopt();
+
+	var optsClassNames = command.opts['--classNames']
+	var classNames = optsClassNames ? optsClassNames.split(' ') : [];
+
+	if (classNames.length) {
+		return testClassNames(command, classNames, callback);
+	}
+	return testAll(command, callback);
+};

--- a/lib/test-result-formatting.js
+++ b/lib/test-result-formatting.js
@@ -1,0 +1,94 @@
+'use strict';
+
+var chalk = require('chalk');
+var _ = require('underscore');
+var utils = require('./utils');
+
+var formatSuccessLine = function(success) {
+	return success.name + '#' + success.methodName + ' took ' + success.time
+};
+
+var formatSuccesses = function(testResult) {
+	var successes = utils.ensureArray(testResult.successes);
+
+	if (!successes.length) {
+		return [];
+	}
+
+	return ['Successes:'].concat(_.map(
+		successes, _.compose(chalk.green, formatSuccessLine)
+	));
+};
+
+var formatFailure = function(failure) {
+	return [
+		chalk.red(failure['name'] + '#' + failure['methodName'] + ' took ' + failure['time']),
+		'  - ' + failure['message'],
+		'  - ' + failure['stackTrace']
+	];
+};
+
+var formatFailures = function(testResult) {
+	var failures = utils.ensureArray(testResult.failures);
+
+	if (!failures.length) {
+		return [];
+	}
+
+	return _.flatten(['Failures:'].concat(_.map(failures, function(failure) {
+		return formatFailure(failure);
+	})));
+};
+
+var formatOverview = function(testResult) {
+	var successCount = utils.ensureArray(testResult.successes).length;
+	var failureCount = utils.ensureArray(testResult.failures).length;
+	var testCount = successCount + failureCount;
+	var testCountText = testCount + ' method' + (testCount === 1 ? '' : 's');
+	var failureCountText = failureCount + ' failure' + (failureCount === 1 ? '' : 's');
+
+	return [testCountText + ', ' + failureCountText];
+};
+
+var formatCodeCoverageWarnings = function(testResult) {
+	var warnings = utils.ensureArray(testResult.codeCoverageWarnings);
+
+	if (!warnings.length) {
+		return [];
+	}
+
+	return ['Code Coverage Warnings:'].concat(warnings.map(function(warning) {
+		var name = warning.name;
+		var prefix = '';
+
+		if (_.isString(name)) {
+			prefix = name + ': ';
+		}
+
+		return prefix + warning.message;
+	}));
+};
+
+var formatComponentFailures = function(deployDetails) {
+	var componentFailures = utils.ensureArray(deployDetails.componentFailures);
+
+	if (!componentFailures.length) {
+		return [];
+	}
+
+	return ['Component Failures:'].concat(componentFailures.map(function(f) {
+		if (f.fullName && f.componentType) {
+			return ' - ' + f.problemType + " in " + f.componentType + " component '" + f.fullName + "': " + f.problem;
+		} else {
+			return ' - ' + f.problemType + " in file '" + f.fileName + "': " + f.problem;
+		}
+	}));
+};
+
+module.exports = {
+	formatSuccesses: formatSuccesses,
+	formatFailures: formatFailures,
+	formatOverview: formatOverview,
+	formatCodeCoverageWarnings: formatCodeCoverageWarnings,
+	formatComponentFailures: formatComponentFailures
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,15 @@
 "use strict";
 
 var path = require('path');
+var _ = require('underscore');
 var describeMetadataService = new(require('./describe-metadata-service'))();
+
+exports.ensureArray = function(objectOrArray) {
+	if (!objectOrArray) {
+		return [];
+	}
+	return _.isArray(objectOrArray) ? objectOrArray : [objectOrArray];
+};
 
 exports.getFileNameWithoutExtension = function(filename) {
 	return path.basename(filename).replace(path.extname(filename), '');

--- a/test/data/run-tests-synchronous.js
+++ b/test/data/run-tests-synchronous.js
@@ -1,0 +1,88 @@
+'use strict';
+
+exports.response = {
+	successes: [{
+		namespace: null,
+		name: 'Test_OpportunityController',
+		methodName: 'isSoFine',
+		id: '01pD0000000mL3EIAU',
+		time: 4661,
+		seeAllData: true
+	}, {
+		namespace: null,
+		name: 'Test_QuoteController',
+		methodName: 'isSoCool',
+		id: '01pD0000000mQrWIAU',
+		time: 717,
+		seeAllData: false
+	}],
+	failures: [{
+		type: 'Class',
+		namespace: 'MyNamespace',
+		name: 'Test_QuoteController',
+		methodName: 'CreateAndSendQuoteTest',
+		message: 'System.NullPointerException: Attempt to de-reference a null object',
+		stackTrace: 'Class.Test_QuoteController: line 76, column 1',
+		id: '01pD0000000mQrWIAU',
+		seeAllData: true,
+		time: 4279,
+		packageName: 'Test_QuoteController'
+	}, {
+		type: 'Class',
+		namespace: 'MyNamespace',
+		name: 'Test_QuoteController',
+		methodName: 'getCurrentUserName',
+		message: 'System.NullPointerException: Attempt to de-reference a null object',
+		stackTrace: 'Class.Test_QuoteController: line 76, column 1',
+		id: '01pD0000000mQrWIAU',
+		seeAllData: true,
+		time: 1518,
+		packageName: 'Test_QuoteController'
+	}, {
+		type: 'Class',
+		namespace: 'MyNamespace',
+		name: 'Test_QuoteController',
+		methodName: 'getQuoteLineItemTest',
+		message: 'System.NullPointerException: Attempt to de-reference a null object',
+		stackTrace: 'Class.Test_QuoteController: line 76, column 1',
+		id: '01pD0000000mQrWIAU',
+		seeAllData: true,
+		time: 1597,
+		packageName: 'Test_QuoteController'
+	}],
+	totalTime: 12772,
+	apexLogId: null,
+	numTestsRun: 5,
+	codeCoverage: [{
+		locationsNotCovered: [],
+		soslInfo: [],
+		dmlInfo: [],
+		numLocations: 2,
+		numLocationsNotCovered: 0,
+		soqlInfo: [],
+		methodInfo: [],
+		name: 'QuoteController',
+		id: '01pD0000000mVvEIAU',
+		type: 'Class',
+		namespace: 'MyNamespace'
+	}, {
+		locationsNotCovered: [Object],
+		soslInfo: [],
+		dmlInfo: [],
+		numLocations: 96,
+		numLocationsNotCovered: 13,
+		soqlInfo: [],
+		methodInfo: [],
+		name: 'OpportunityController',
+		id: '01qD000000065E4IAI',
+		type: 'Class',
+		namespace: null
+	}],
+	numFailures: 3,
+	codeCoverageWarnings: [{
+		id: '01qD000000065E4IAI',
+		name: 'OpportunityController',
+		namespace: null,
+		message: 'Test coverage of selected Apex Class is 13%, at least 90% test coverage is required'
+	}]
+};

--- a/test/test-result-formatting.js
+++ b/test/test-result-formatting.js
@@ -1,0 +1,133 @@
+'use strict';
+
+var assert = require('assert');
+var chalk = require('chalk');
+
+var formatting = require('../lib/test-result-formatting');
+var res = require('./data/run-tests-synchronous').response;
+
+describe('test-result-formatting', function() {
+	describe('.formatSuccesses', function() {
+		it('formats successful test results', function() {
+			assert.deepEqual(
+				formatting.formatSuccesses(res), [
+					'Successes:',
+					chalk.green('Test_OpportunityController#isSoFine took 4661'),
+					chalk.green('Test_QuoteController#isSoCool took 717')
+				]
+			);
+		});
+
+		it('can handle test results with a successes Object', function() {
+			var testResponse = {
+				successes: res.successes[0]
+			};
+			assert.deepEqual(
+				formatting.formatSuccesses(testResponse), [
+					'Successes:',
+					chalk.green('Test_OpportunityController#isSoFine took 4661')
+				]
+			);
+		});
+
+		it('can handle test results w/o successes', function() {
+			assert.deepEqual(formatting.formatSuccesses({}), []);
+		});
+	});
+
+	describe('.formatFailures', function() {
+		it('formats failed test results', function() {
+			assert.deepEqual(
+				formatting.formatFailures(res), [
+					'Failures:',
+					chalk.red('Test_QuoteController#CreateAndSendQuoteTest took 4279'),
+					'  - System.NullPointerException: Attempt to de-reference a null object',
+					'  - Class.Test_QuoteController: line 76, column 1',
+					chalk.red('Test_QuoteController#getCurrentUserName took 1518'),
+					'  - System.NullPointerException: Attempt to de-reference a null object',
+					'  - Class.Test_QuoteController: line 76, column 1',
+					chalk.red('Test_QuoteController#getQuoteLineItemTest took 1597'),
+					'  - System.NullPointerException: Attempt to de-reference a null object',
+					'  - Class.Test_QuoteController: line 76, column 1'
+				]
+			);
+
+			it('can handle test results with a failures Object', function() {
+				var testResponse = {
+					failures: res.failures[0]
+				};
+				assert.deepEqual(
+					formatting.formatFailures(testResponse), [
+						'Failures:',
+						chalk.red('Test_QuoteController#CreateAndSendQuoteTest took 4279'),
+						'  - System.NullPointerException: Attempt to de-reference a null object',
+						'  - Class.Test_QuoteController: line 76, column 1',
+						chalk.red('Test_QuoteController#getCurrentUserName took 1518'),
+						'  - System.NullPointerException: Attempt to de-reference a null object',
+						'  - Class.Test_QuoteController: line 76, column 1',
+						chalk.red('Test_QuoteController#getQuoteLineItemTest took 1597'),
+						'  - System.NullPointerException: Attempt to de-reference a null object',
+						'  - Class.Test_QuoteController: line 76, column 1'
+					]
+				);
+			});
+
+			it('can handle test results w/o failures', function() {
+				assert.deepEqual(formatting.formatFailures({}), []);
+			});
+		});
+	});
+
+	describe('.formatOverview', function() {
+		it('formats overview of test results', function() {
+			assert.deepEqual(
+				formatting.formatOverview(res), ["5 methods, 3 failures"]
+			);
+		});
+
+		it('can handle test results with failures and successes Objects', function() {
+			var testResponse = {
+				failures: res.failures[0],
+				successes: res.successes[0]
+			};
+			assert.deepEqual(
+				formatting.formatOverview(testResponse), ["2 methods, 1 failure"]
+			);
+		});
+
+		it('can handle test results w/o tests', function() {
+			assert.deepEqual(
+				formatting.formatOverview({}), ["0 methods, 0 failures"]
+			);
+		});
+	});
+
+	describe('.formatCodeCoverageWarnings', function() {
+		context('when running some tests', function() {
+			it('formats code coverage warnings of test result', function() {
+				assert.deepEqual(
+					formatting.formatCodeCoverageWarnings(res), [
+						'Code Coverage Warnings:',
+						'OpportunityController: Test coverage of selected Apex Class is 13%, at least 90% test coverage is required'
+					]
+				);
+			});
+
+			it('can handle test results with a codeCoverageWarnings Object', function() {
+				var testResponse = {
+					codeCoverageWarnings: res.codeCoverageWarnings[0]
+				};
+				assert.deepEqual(
+					formatting.formatCodeCoverageWarnings(testResponse), [
+						'Code Coverage Warnings:',
+						'OpportunityController: Test coverage of selected Apex Class is 13%, at least 90% test coverage is required'
+					]
+				);
+			});
+
+			it('can handle test results w/o code coverage warnings', function() {
+				assert.deepEqual(formatting.formatCodeCoverageWarnings({}), []);
+			});
+		});
+	});
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,6 +5,31 @@ var metadataUtils = require("../lib/utils");
 var path = require('path');
 
 describe('MetadataUtils', function() {
+	describe('#ensureArray()', function() {
+		context('when passed an Array', function() {
+			it('returns the argument', function() {
+				var array = ['i am an array']
+				assert.strictEqual(metadataUtils.ensureArray(array), array);
+			});
+		});
+
+		context('when passed an Object', function() {
+			it('returns an Array containing the Object', function() {
+				var object = {
+					iAm: 'an object'
+				};
+				assert.deepEqual(metadataUtils.ensureArray(object), [object]);
+			});
+		});
+
+		context('when passed a falsy value', function() {
+			it('returns an empty Array', function() {
+				assert.deepEqual(metadataUtils.ensureArray(null), []);
+				assert.deepEqual(metadataUtils.ensureArray(undefined), []);
+			});
+		});
+	});
+
 	describe('#getFileNameWithoutExtension()', function() {
 		it('should return the filename without extension', function() {
 			assert.deepEqual(metadataUtils.getFileNameWithoutExtension(path.join('pages', 'Test.page')), 'Test');


### PR DESCRIPTION
This is continuing what we discussed in #40. I had some time on my hands during a longer train ride on the weekend. So I gave it a try.

# Feature

* `force-dev-tool test` accepts a `--classNames` option to execute specific test cases given by their names.
* `force-dev-tool test` accepts a `--verbose` option to show information about successful tests.

# Implementation

I rewrote `lib/cli/test` to handle both cases: *Run all tests* & *Run some tests*.

# Notes

## Modularization and function reuse

I rewrote `lib/cli/test` in a more functional manner (no need for inheritance here). The file now consists of a lot of small functions. Some of those could be extracted to `lib/utils` or something similar, e.g `printStartingMessage`, `logToConsole` and `login`. These functions could then be reused in other `lib/cli/*` files. 

## Testing

Also, other functions like `runTestsSynchronous` and `testClassNames` could be taken out to be tested in isolation. The great part about having functions like this, is that we can basically test a lot of the `cli` functionality without all the `Command`s and `Connection`s actually being set up. So we could e.g. mock a `connection` and then test `runTestsSynchronous`.

# Conclusion

I did not want to introduce to many new concepts here, I kept the code in `lib/cli/test` mostly untested except the `test-result-formatting` utility collection to stick with the existing style. I suggest to merge this and play with it to see, if you like the functional composition style of `lib/cli/test` and, if you feel like this could benefit the project, it would be an easy task to convert the other modules to rely on functional composition rather than protootypical inheritance.

# Sample Outputs

## `force-dev-tool test`

### Before

```bash
Running Test execution to remote dev

Error: Test execution failed.
 - System.NullPointerException: Attempt to de-reference a null object, stackTrace: Class.Test_QuoteController: line 76, column 1
 - System.NullPointerException: Attempt to de-reference a null object, stackTrace: Class.Test_QuoteController: line 76, column 1
 - System.NullPointerException: Attempt to de-reference a null object, stackTrace: Class.Test_QuoteController: line 76, column 1
 - Average test coverage across all Apex Classes and Triggers is 71%, at least 75% test coverage is required.
Visit https://SALESFORCEURL/changemgmt/monitorDeploymentsDetails.apexp?asyncId=SF_ID for more information.
```

### After

```bash
Running Test execution to remote dev

Failures:
Test_QuoteController#CreateAndSendQuoteTest took 1572.0
  - System.NullPointerException: Attempt to de-reference a null object
  - Class.Test_QuoteController: line 76, column 1
Test_QuoteController#getCurrentUserName took 1338.0
  - System.NullPointerException: Attempt to de-reference a null object
  - Class.Test_QuoteController: line 76, column 1
Test_QuoteController#getQuoteLineItemTest took 1315.0
  - System.NullPointerException: Attempt to de-reference a null object
  - Class.Test_QuoteController: line 76, column 1
Code Coverage Warnings:
Average test coverage across all Apex Classes and Triggers is 71%, at least 75% test coverage is required.
Error: Visit https://cs83.salesforce.com/changemgmt/monitorDeploymentsDetails.apexp?asyncId=0Af4E000008Cv3SSAS for more information.
289 methods, 3 failures
```

## `force-dev-tool test --classNames 'Test_DecoratedOpportunity Test_QuoteController'`

```bash
Running Test execution to remote dev

Failures:
Test_QuoteController#CreateAndSendQuoteTest took 1536
  - System.NullPointerException: Attempt to de-reference a null object
  - Class.Test_QuoteController: line 76, column 1
Test_QuoteController#getCurrentUserName took 1238
  - System.NullPointerException: Attempt to de-reference a null object
  - Class.Test_QuoteController: line 76, column 1
Test_QuoteController#getQuoteLineItemTest took 1143
  - System.NullPointerException: Attempt to de-reference a null object
  - Class.Test_QuoteController: line 76, column 1
Error: 40 methods, 3 failures
```

Let me know, what you think.

Cheers!
