### PR TITLE
filter file properties with invalid type

### DIFF
--- a/lib/fetch-result-parser.js
+++ b/lib/fetch-result-parser.js
@@ -47,6 +47,9 @@ FetchResultParser.prototype.getComponents = function(opts) {
 	self.transform();
 	self.filterInvalid();
 	self.fileProperties.forEach(function(fileProperty) {
+		if (!fileProperty.type || typeof fileProperty.type !== 'string') {
+			return;
+		}
 		components.push(
 			new MetadataComponent({
 				type: fileProperty.type,


### PR DESCRIPTION
e.g. `{"$": {"xsi:nil": "true"} }` for StandardValueSetTranslation currently listed with API version 38.0