### PR TITLE
Fix running specific tests

### DIFF
--- a/lib/cli/test.js
+++ b/lib/cli/test.js
@@ -65,7 +65,13 @@ var login = function(remote, onSuccess, onError) {
 var runTestsSynchronous = function(connection, classNames, verbose, callback) {
 	var conn = connection;
 
-	return conn.tooling.runTestsSynchronous(classNames, function(err, res) {
+	// see comments in https://github.com/jsforce/jsforce/issues/493
+	var runTestsSynchronousGet = function(classnames, callback) {
+		var url = conn.tooling._baseUrl() + "/runTestsSynchronous/?classnames=" + classnames.join(',');
+		return conn.tooling.request(url).thenCall(callback);
+	}
+
+	return runTestsSynchronousGet(classNames, function(err, res) {
 		if (err) {
 			return callback(err);
 		}

--- a/lib/cli/test.js
+++ b/lib/cli/test.js
@@ -12,11 +12,38 @@ var formatting = require('../test-result-formatting');
 var doc = "Usage:\n" +
 	"	force-dev-tool test [options] [<remote>]\n" +
 	"\n" +
+	"Run unit tests.\n" +
+	"Running all tests is being achieved by performing an **empty** test deployment (validation) with testLevel=RunLocalTests.\n" +
+	"Running specified tests is being achieved by using the Tooling API runTestsSynchronous method.\n" +
+	"\n" +
 	"Options:\n" +
-	"	--classNames=<classNames>    Names of Test Classes separated by spaces. Supported API versions =< 36.0\n" +
+	"	--classNames=<classNames>    Names of Test Classes separated by whitespace. Supported API versions =< 36.0\n" +
 	"	--apiVersion=<apiVersion>    API version.\n" +
 	"	--verbose                    Print log messages for successful test methods.\n" +
-	"	-d=<directory>               Directory containing the metadata and package.xml.";
+	"	-d=<directory>               Directory containing the metadata and package.xml.\n" +
+	"\n" +
+	"Examples:\n" +
+	"\n" +
+	"	Running all local tests\n" +
+	"		$ force-dev-tool test\n" +
+	"		Running Test execution to remote mydev\n" +
+	"		Failures:\n" +
+	"		Test_Foo#test_method_one took 32.0\n" +
+	"		  - System.AssertException: Assertion Failed: Expected: foo, Actual: bar\n" +
+	"		  - Class.Test_Foo.test_method_one: line 8, column 1\n" +
+	"		Test_Foo2#test_method_one took 11.0\n" +
+	"		  - System.AssertException: Assertion Failed\n" +
+	"		  - Class.Test_Foo2.test_method_one: line 7, column 1\n" +
+	"		Error: Visit https://mynamespace.my.salesforce.com/changemgmt/monitorDeploymentsDetails.apexp?asyncId=REDACTED for more information.\n" +
+	"		3 methods, 2 failures\n" +
+	"\n" +
+	"	Running specified test classes\n" +
+	"		$ force-dev-tool test --classNames 'Test_MockFoo Test_MockBar'\n" +
+	"\n" +
+	"	Running test classes matching a pattern (in src/package.xml)\n" +
+	"		$ force-dev-tool package grep 'ApexClass/Test_Mock*' \\\n" +
+	"		 | cut -d '/' -f 2 \\\n" +
+	"		 | xargs -0 force-dev-tool test --classNames";
 
 var printStartingMessage = function(remote) {
 	console.log('Running Test execution to remote ' + chalk.cyan(remote.name));
@@ -186,8 +213,13 @@ SubCommand.prototype.process = function(proc, callback) {
 	var command = this;
 	command.opts = command.opts ? command.opts : command.docopt();
 
-	var optsClassNames = command.opts['--classNames']
-	var classNames = optsClassNames ? optsClassNames.split(' ') : [];
+	var optsClassNames = command.opts['--classNames'];
+	// allow even newlines as separator
+	var classNames = optsClassNames ? optsClassNames.split(/\s+/g) : [];
+	// trim each item and remove empty items
+	classNames = classNames.map(function(item) {
+		return item.trim();
+	}).filter(Boolean);
 
 	if (classNames.length) {
 		return testClassNames(command, classNames, callback);


### PR DESCRIPTION
It looks like jsforce@1.7.1 broke running tests with specific classNames.

We now explicitly call runTestsSynchronous with GET method.