### PR TITLE
fix package.xml generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ force-dev-tool package -a
 Created src/package.xml
 ```
 
-In order to exclude certain metadata components from being added to the `package.xml` file, add patterns (similar to `.gitignore`) to `.forceignore`.
+In order to exclude certain metadata components from being added to the `package.xml` file, add patterns (similar to `.gitignore`) to `.forceignore`. See [here](https://gist.github.com/amtrack/7b99d31b60971b95dda801fd58288257) for some sane default rules.
 
 **Retrieving metadata**
 

--- a/lib/cli/changeset.js
+++ b/lib/cli/changeset.js
@@ -101,11 +101,15 @@ SubCommand.prototype.process = function(proc, callback) {
 		});
 		// 3. attach missing files and filter
 		metadataContainer.manifest.apiVersion = apiVersion;
-		metadataContainer = metadataContainer
-			.completeMetadataWith({
-				path: self.project.storage.getSrcPath()
-			})
-			.filter(metadataContainer.manifest);
+		try {
+			metadataContainer = metadataContainer
+				.completeMetadataWith({
+					path: self.project.storage.getSrcPath()
+				})
+				.filter(metadataContainer.manifest);
+		} catch (containerError) {
+			return callback(containerError);
+		}
 		// unnamed children have to be listed using its parent component
 		metadataContainer.manifest.rollup();
 		// unnamed children are being deleted implicitly

--- a/lib/describe-metadata-service.js
+++ b/lib/describe-metadata-service.js
@@ -149,10 +149,45 @@ var childTypes = [{
 	parent: 'PermissionSet',
 	key: 'apexClass'
 }, {
+	xmlName: 'PermissionSetApexPageAccess',
+	tagName: 'pageAccesses',
+	parent: 'PermissionSet',
+	key: 'apexPage'
+}, {
+	xmlName: 'PermissionSetCustomPermissions',
+	tagName: 'customPermissions',
+	parent: 'PermissionSet',
+	key: 'name'
+}, {
+	xmlName: 'PermissionSetExternalDataSourceAccess',
+	tagName: 'externalDataSourceAccesses',
+	parent: 'PermissionSet',
+	key: 'externalDataSource'
+}, {
 	xmlName: 'PermissionSetFieldPermissions',
 	tagName: 'fieldPermissions',
 	parent: 'PermissionSet',
 	key: 'field'
+}, {
+	xmlName: 'PermissionSetObjectPermissions',
+	tagName: 'objectPermissions',
+	parent: 'PermissionSet',
+	key: 'object'
+}, {
+	xmlName: 'PermissionSetRecordTypeVisibility',
+	tagName: 'recordTypeVisibilities',
+	parent: 'PermissionSet',
+	key: 'recordType'
+}, {
+	xmlName: 'PermissionSetTabSetting',
+	tagName: 'tabSettings',
+	parent: 'PermissionSet',
+	key: 'tab'
+}, {
+	xmlName: 'PermissionSetUserPermission',
+	tagName: 'userPermissions',
+	parent: 'PermissionSet',
+	key: 'name'
 }, {
 	xmlName: 'ProfileApplicationVisibility',
 	tagName: 'applicationVisibilities',
@@ -164,10 +199,50 @@ var childTypes = [{
 	parent: 'Profile',
 	key: 'apexClass'
 }, {
+	xmlName: 'ProfileApexPageAccess',
+	tagName: 'pageAccesses',
+	parent: 'Profile',
+	key: 'apexPage'
+}, {
+	xmlName: 'ProfileCustomPermissions',
+	tagName: 'customPermissions',
+	parent: 'Profile',
+	key: 'name'
+}, {
+	xmlName: 'ProfileExternalDataSourceAccess',
+	tagName: 'externalDataSourceAccesses',
+	parent: 'Profile',
+	key: 'externalDataSource'
+}, {
 	xmlName: 'ProfileFieldLevelSecurity',
 	tagName: 'fieldPermissions',
 	parent: 'Profile',
 	key: 'field'
+}, {
+	xmlName: 'ProfileLayoutAssignments',
+	tagName: 'layoutAssignments',
+	parent: 'Profile',
+	key: 'layout'
+}, {
+	xmlName: 'ProfileObjectPermissions',
+	tagName: 'objectPermissions',
+	parent: 'Profile',
+	key: 'object'
+}, {
+	xmlName: 'ProfileRecordTypeVisibility',
+	tagName: 'recordTypeVisibilities',
+	parent: 'Profile',
+	key: 'recordType'
+}, {
+	xmlName: 'ProfileTabVisibility',
+	tagName: 'tabVisibilities',
+	parent: 'Profile',
+	key: 'tab'
+}, {
+	xmlName: 'ProfileUserPermission',
+	tagName: 'userPermissions',
+	parent: 'Profile',
+	key: 'name'
 }];
 
 var metadataTypesAdditions = [];

--- a/lib/describe-metadata-service.js
+++ b/lib/describe-metadata-service.js
@@ -3,11 +3,24 @@
 var _ = require('underscore');
 var path = require('path');
 
+// TODO: this should be parsed from Metadata WSDL
 var childTypes = [{
 	xmlName: 'ActionOverride',
 	tagName: 'actionOverrides',
 	parent: 'CustomObject',
 	key: 'actionName'
+}, {
+	xmlName: 'AssignmentRule',
+	tagName: 'assignmentRule',
+	parent: 'AssignmentRules',
+	key: 'fullName',
+	isNamed: true
+}, {
+	xmlName: 'AutoResponseRule',
+	tagName: 'autoResponseRule',
+	parent: 'AutoResponseRules',
+	key: 'fullName',
+	isNamed: true
 }, {
 	xmlName: 'CustomField',
 	tagName: 'fields',
@@ -47,6 +60,18 @@ var childTypes = [{
 	tagName: 'sharingReasons',
 	parent: 'CustomObject',
 	key: 'fullName'
+}, {
+	xmlName: 'SharingCriteriaRule',
+	tagName: 'sharingCriteriaRules',
+	parent: 'SharingRules',
+	key: 'fullName',
+	isNamed: true
+}, {
+	xmlName: 'SharingOwnerRule',
+	tagName: 'sharingOwnerRules',
+	parent: 'SharingRules',
+	key: 'fullName',
+	isNamed: true
 }, {
 	xmlName: 'ListView',
 	tagName: 'listViews',
@@ -101,6 +126,12 @@ var childTypes = [{
 	key: 'fullName',
 	isNamed: true
 }, {
+	xmlName: 'MatchingRule',
+	tagName: 'matchingRules',
+	parent: 'MatchingRules',
+	key: 'fullName',
+	isNamed: true
+}, {
 	xmlName: 'CustomLabel',
 	tagName: 'labels',
 	parent: 'CustomLabel',
@@ -145,6 +176,9 @@ var DescribeMetadataService = module.exports = function(describeMetadataResult) 
 	var self = this;
 	self.describeMetadataResult = describeMetadataResult ? describeMetadataResult : require('./describe-metadata-result.json');
 	self.metadataObjectsExtended = [];
+	if (!self.describeMetadataResult.metadataObjects) {
+		self.describeMetadataResult.metadataObjects = [];
+	}
 	self.describeMetadataResult.metadataObjects.forEach(function(metadataObject) {
 		var additionalChildTypes = _.where(childTypes, {
 			'parent': metadataObject.xmlName

--- a/lib/describe-remote.js
+++ b/lib/describe-remote.js
@@ -131,6 +131,8 @@ DescribeRemote.prototype.fetchFileProperties = function(cbFileProperties) {
 			var childXmlNames = _.pluck(_.filter(self.describeMetadataResult.metadataObjects, function(type) {
 				return type.childXmlNames;
 			}), 'childXmlNames');
+			// don't try to list metadata of invalid child type ManagedTopic
+			childXmlNames = _.without(_.flatten(childXmlNames), 'ManagedTopic');
 			metadataTypeNames = _.flatten([].concat(metadataTypeNames, childXmlNames));
 			filePropertyQueries = metadataTypeNames.map(function(item) {
 				return {

--- a/lib/fetch-result-parser.js
+++ b/lib/fetch-result-parser.js
@@ -142,6 +142,12 @@ FetchResultParser.prototype.transform = function() {
 			if (personAccountRecordTypeMatch) {
 				fileProperty.fullName = 'PersonAccount.' + itemName;
 			}
+		} else if (fileProperty.type === 'CustomFeedFilter') {
+			// Apparently the fullName returned in the FileProperty does not include the necessary Case prefix:
+			// http://salesforce.stackexchange.com/questions/156714/listmetadata-query-of-type-customfeedfilter-returns-fullname-without-sobject
+			if (fileProperty.fullName.indexOf('.') < 0) {
+				fileProperty.fullName = 'Case.' + fileProperty.fullName;
+			}
 		}
 		return fileProperty;
 	});

--- a/lib/fetch-result-parser.js
+++ b/lib/fetch-result-parser.js
@@ -50,9 +50,6 @@ FetchResultParser.prototype.getComponents = function(opts) {
 	self.transform();
 	self.filterInvalid();
 	self.fileProperties.forEach(function(fileProperty) {
-		if (!fileProperty.type || typeof fileProperty.type !== 'string') {
-			return;
-		}
 		components.push(
 			new MetadataComponent({
 				type: fileProperty.type,
@@ -154,7 +151,16 @@ FetchResultParser.prototype.transform = function() {
 FetchResultParser.prototype.filterInvalid = function() {
 	var self = this;
 	var folderTypes = getFolderTypes();
+	var describeMetadataService = new(require('./describe-metadata-service'))(self.describeMetadataResult);
+	var metadataObjectsExtended = describeMetadataService.getTypes();
+
 	self.fileProperties = _.filter(self.fileProperties, function(fileProperty) {
+		if (!fileProperty.type || typeof fileProperty.type !== 'string') {
+			return false;
+		}
+		var metadataType = _.findWhere(metadataObjectsExtended, {
+			xmlName: fileProperty.type
+		});
 		if (folderTypes.indexOf(fileProperty.type) > -1 && fileProperty.fullName === 'unfiled$public') {
 			// we don't consider this as a warning
 			// self.warnings.push('Warning: Skipped standard ' + fileProperty.type + ': ' + fileProperty.fullName);
@@ -165,8 +171,8 @@ FetchResultParser.prototype.filterInvalid = function() {
 		} else if (fileProperty.type === 'Flow' && !new RegExp('^.*-[0-9]+$').test(fileProperty.fullName)) {
 			self.warnings.push('Warning: Skipped non-versioned Flow: ' + fileProperty.fullName);
 			return false;
-		} else if (fileProperty.type === 'CustomLabels' && fileProperty.fullName === 'CustomLabels') {
-			// use CustomLabel/MyLabel instead
+		} else if (metadataType.childXmlNames && ['CustomObject', 'Profile', 'PermissionSet'].indexOf(fileProperty.type) < 0) {
+			// don't list types which have named children only
 			return false;
 		}
 		return true;

--- a/lib/metadata-container.js
+++ b/lib/metadata-container.js
@@ -64,13 +64,11 @@ MetadataContainer.prototype.filter = function(manifest) {
 			});
 			var component = metadataFile.getComponent();
 			if (!component) {
-				console.error('Could not determine component for filename: ' + componentFileName);
-				return;
+				throw new Error('Could not determine component for filename: ' + componentFileName);
 			}
 			var type = component.getMetadataType();
 			if (!type) {
-				console.error('Could not determine type for filename ' + componentFileName);
-				return;
+				throw new Error('Could not determine type for filename ' + componentFileName);
 			}
 			// 1. container files
 			if (metadataFile instanceof MetadataFileContainer) {
@@ -98,6 +96,9 @@ MetadataContainer.prototype.filter = function(manifest) {
 							type: cmp.type,
 							fullName: cmp.fullName
 						});
+						if (!c) {
+							throw new Error("Could not find component '" + cmp + "' in '" + component + "'");
+						}
 						containerFile.addComponent(c);
 					});
 					filteredMetadataContainer.add(containerFile, []);


### PR DESCRIPTION
This changes the way the package.xml file is being generated!

While previously metadata types **and** their child types (such as `Workflow` -> `WorkflowRule`, `WorkflowFieldUpdate`,...) were being listed in the package.xml, now only the child types are being listed by default.

There is an exception for `MatchingRules` and `MatchingRule` where trying to list file properties of `MatchingRule` failed. Here only the parent type is being listed.

For types that have own properties (`CustomObject`), the parent type is still being listed together with its child types.
For types where child types cannot be listed in the package.xml (`Profile` and `PermissionSet`), the parent type is being listed.