### PR TITLE
Feature/memory tweaks

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -16,8 +16,9 @@ Diff.prototype.data = function() {
 	return this.data;
 };
 
-Diff.prototype.getMetadataContainers = function() {
+Diff.prototype.getMetadataContainers = function(opts) {
 	var self = this;
+	var opts = opts || {};
 	var containerFrom = new MetadataContainer();
 	var containerTo = new MetadataContainer();
 	var files = parseDiff(self.data);
@@ -26,11 +27,13 @@ Diff.prototype.getMetadataContainers = function() {
 		if (Utils.isValidFilename(file.from) || Utils.isValidFilename(file.to) || Utils.isValidMetaFilename(file.from) || Utils.isValidMetaFilename(file.to)) {
 			var fileFrom = MetadataFileFactory.createInstance({
 				path: file.from === '/dev/null' ? file.from : path.relative(unpackagedPath, file.from),
-				contents: new Buffer("")
+				contents: new Buffer(""),
+				ignoreWhitespace: opts.ignoreWhitespace
 			});
 			var fileTo = MetadataFileFactory.createInstance({
 				path: file.to === '/dev/null' ? file.to : path.relative(unpackagedPath, file.to),
-				contents: new Buffer("")
+				contents: new Buffer(""),
+				ignoreWhitespace: opts.ignoreWhitespace
 			});
 			if (file.index && file.index.length) {
 				// retrieve file using git

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -18,7 +18,7 @@ Diff.prototype.data = function() {
 
 Diff.prototype.getMetadataContainers = function(opts) {
 	var self = this;
-	var opts = opts || {};
+	opts = opts || {};
 	var containerFrom = new MetadataContainer();
 	var containerTo = new MetadataContainer();
 	var files = parseDiff(self.data);

--- a/lib/metadata-file-container.js
+++ b/lib/metadata-file-container.js
@@ -77,6 +77,19 @@ MetadataFileContainer.prototype.diff = function(other) {
 			}));
 		});
 	}
+
+	//filter and cleanup
+	if(_.isArray(self.components)){
+		self.components = _.filter(self.components, function(component){
+			return component.keep
+		});
+	}
+	if(_.isArray(other.components)){
+		other.components = _.filter(other.components, function(component){
+			return component.keep
+		});
+	}
+
 	return {
 		added: added,
 		modified: modified,
@@ -123,6 +136,7 @@ MetadataFileContainer.prototype.parse = function() {
 					}
 				}
 			});
+
 		});
 	}
 	return self;
@@ -190,10 +204,12 @@ MetadataFileContainer.diffMaps = function(mapA, mapB) {
 				// is not new
 				if (!_.isEqual(mapA[type][member], mapB[type][member])) {
 					// has changed
+					mapB[type][member].keep = true;
 					diffResult.modified.add(mapB[type][member]);
 				}
 			} else {
 				// is new
+				mapB[type][member].keep = true;				
 				diffResult.added.add(mapB[type][member]);
 			}
 		});
@@ -202,6 +218,7 @@ MetadataFileContainer.diffMaps = function(mapA, mapB) {
 		Object.keys(mapA[type]).forEach(function(member) {
 			if (!(mapB[type] && mapB[type][member])) {
 				// is deleted
+				mapA[type][member].keep = true;				
 				diffResult.deleted.add(mapA[type][member]);
 			}
 		});

--- a/lib/metadata-file-container.js
+++ b/lib/metadata-file-container.js
@@ -12,6 +12,7 @@ var describeMetadataService = new(require('./describe-metadata-service'))();
 // though some components are not being listed in the manifest
 var MetadataFileComponent = function(opts) {
 	MetadataComponent.call(this, opts);
+	this.opts = opts || {};
 }
 
 MetadataFileComponent.prototype = Object.create(MetadataComponent.prototype);
@@ -19,6 +20,7 @@ MetadataFileComponent.prototype.constructor = MetadataFileComponent;
 
 var MetadataFileContainer = module.exports = function(opts) {
 	MetadataFile.call(this, opts);
+	this.opts = opts || {};
 	this.components = [];
 	this.parse();
 };
@@ -129,7 +131,7 @@ MetadataFileContainer.prototype.parse = function() {
 							contents: "    " + field.toString({
 								compressed: true,
 								trimmed: false,
-								preserveWhitespace: true
+								preserveWhitespace: !self.opts.ignoreWhitespace
 							}),
 							parent: type
 						}));


### PR DESCRIPTION
@amtrack These changes are because I was running into some issues with node running out of memory while creating a changeset that included some pretty large files.  

I traced it down to components being kept in memory after the parsing and comparison, so was able to significantly reduce memory usage but filtering out any unmodified children. 

There's probably some additional memory usage improvements that could be made (perhaps using streams) but this was the easiest for now. 

Also added an option to ignore whitespace, so whitespace changes aren't picked up by the diffMap method (which was causing issues for me as well).

This tool is very useful, thank you for creating it! 

Feel free to decline these changes... just thought I'd share...