### PR TITLE
for Report & Dashboard meta files were excluded

### DIFF
--- a/lib/describe-metadata-result.json
+++ b/lib/describe-metadata-result.json
@@ -123,13 +123,13 @@
 	}, {
 		"directoryName": "reports",
 		"inFolder": true,
-		"metaFile": false,
+		"metaFile": true,
 		"suffix": "report",
 		"xmlName": "Report"
 	}, {
 		"directoryName": "dashboards",
 		"inFolder": true,
-		"metaFile": false,
+		"metaFile": true,
 		"suffix": "dashboard",
 		"xmlName": "Dashboard"
 	}, {

--- a/lib/metadata-file.js
+++ b/lib/metadata-file.js
@@ -107,7 +107,7 @@ MetadataFile.prototype.getComponent = function() {
 	} else if (metadataType.inFolder) {
 		var fileNameParts = [metadataFile.basename];
 		var fullNameParts = [metadataType.xmlName === 'Document' ? metadataFile.basename : metadataFile.filename()];
-		if (metadataFile.parentDirname()) {
+		if (metadataFile.parentDirname() && metadataFile.parentDirname() !== '..') {
 			// not a Folder, then prepend folder name
 			fileNameParts.unshift(metadataFile.basenameDirname());
 			fullNameParts.unshift(metadataFile.basenameDirname());


### PR DESCRIPTION
meta files exist to give access rights, they were excluded because of folder problem and meta set to false
Changes solves folder problem but gives errors for report files not having meta (I don't see a way to deal with it for the moment)