### PR TITLE
Support profile layout assignments for multiple record types

### DIFF
--- a/lib/describe-metadata-service.js
+++ b/lib/describe-metadata-service.js
@@ -235,7 +235,8 @@ var childTypes = [{
 	xmlName: 'ProfileLayoutAssignments',
 	tagName: 'layoutAssignments',
 	parent: 'Profile',
-	key: 'layout'
+	key: 'layout',
+	value: 'recordType'
 }, {
 	xmlName: 'ProfileObjectPermissions',
 	tagName: 'objectPermissions',
@@ -324,6 +325,7 @@ var DescribeMetadataService = module.exports = function(describeMetadataResult) 
 					childMetadataType.parent = childType.parent;
 					childMetadataType.tagName = childType.tagName;
 					childMetadataType.key = childType.key;
+					childMetadataType.value = childType.value;
 					childMetadataType.isNamed = typeof childType.isNamed === 'boolean' ? childType.isNamed : false;
 					childMetadataType.notCustomObjectRelated = typeof childType.notCustomObjectRelated === 'boolean' ? childType.notCustomObjectRelated : false;
 				}

--- a/lib/metadata-file-container.js
+++ b/lib/metadata-file-container.js
@@ -123,9 +123,10 @@ MetadataFileContainer.prototype.parse = function() {
 			parsed.childrenNamed(childType.tagName).forEach(function(field) {
 				if (typeof field['childNamed'] === 'function') {
 					var childMember = field.childNamed(childType.key);
+					var childValue = childType.value && field.childNamed(childType.value);
 					if (childMember && childMember.val) {
 						self.components.push(new MetadataFileComponent({
-							fullName: childType.notCustomObjectRelated ? childMember.val : objectName + '.' + childMember.val,
+							fullName: childType.notCustomObjectRelated ? childMember.val : objectName + '.' + (childValue && childValue.val ? childValue.val + '.' + childMember.val : childMember.val),
 							type: childTypeName,
 							contents: "    " + field.toString({
 								compressed: true,


### PR DESCRIPTION
@amtrack this fixes an issue where if multiple record types were assigned to a single layout in a changeset only one layout was added to the package.