### PR TITLE
chore(ci): update list of Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - v8
-  - v6
-  - v4
+  - "10"
+  - "8"
+  - "6"
 script:
   - npm test
   - npm run fmt
@@ -11,7 +11,7 @@ jobs:
   include:
     - stage: release
       if: branch = master
-      node_js: v8
+      node_js: "10"
       script:
         - npm install --global semantic-release@15
         - semantic-release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
+    - nodejs_version: '10'
     - nodejs_version: '8'
     - nodejs_version: '6'
-    - nodejs_version: '4'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true


### PR DESCRIPTION
BREAKING CHANGE: drop support for Node.js v4

Node.js v4 is EOL since 2018-04-30.