### PR TITLE
fix: creating changesets with explicit patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Succeeded
 
 1\. By explicitly listing metadata files or metadata components
 ```console
-$ force-dev-tool changeset create vat src/pages/AccountExtensionVAT.page CustomField/Account.VAT__c
+$ echo "" | force-dev-tool changeset create vat src/pages/AccountExtensionVAT.page CustomField/Account.VAT__c
 ```
 
 2\. By providing a unified diff (e.g. `git diff`). Tweak the `git diff` command with `--ignore-space-at-eol` or `--ignore-all-space` to ignore space changes.
@@ -134,7 +134,7 @@ exported metadata container to config/deployments/vat
 
 1\. By explicitly listing metadata files or metadata components
 ```console
-$ force-dev-tool changeset create undo-vat --destructive src/pages/AccountExtensionVAT.page CustomField/Account.VAT__c
+$ echo "" | force-dev-tool changeset create undo-vat --destructive src/pages/AccountExtensionVAT.page CustomField/Account.VAT__c
 ```
 
 2\. By providing a unified diff (e.g. `git diff`)

--- a/lib/metadata-container.js
+++ b/lib/metadata-container.js
@@ -341,7 +341,7 @@ MetadataContainer.completeMetadataStream = function(opts) {
 	opts = opts || {};
 	return miss.through.obj(function(metadataContainer, enc, cb) {
 
-		metadataContainer.completeMetadataWith({
+		metadataContainer = metadataContainer.completeMetadataWith({
 			path: opts.path || 'src'
 		}).filter(metadataContainer.manifest);
 		metadataContainer.manifest.rollup();

--- a/test-integration/changeset.js
+++ b/test-integration/changeset.js
@@ -112,3 +112,60 @@ describe("git diff | force-dev-tool changeset create", function() {
 		});
 	});
 });
+
+var explicitTests = [{
+	gitCloneUrl: "https://github.com/amtrack/sfdx-playground.git",
+	branch: "explicit-custom-field",
+	description: "should extract a single CustomField from a CustomObject",
+	patterns: ["CustomField/Account.VAT_Number__c"],
+	unpackaged_path: "src",
+	expected: path.join("config", "deployments", "expected")
+}];
+
+describe("force-dev-tool changeset create ...", function() {
+	var fdt = path.resolve(__dirname, "..", "bin", "cli");
+	explicitTests.forEach(function(test) {
+		it(test.description, function() {
+			if (test.skip) {
+				this.skip();
+			}
+			this.slow(5000);
+			this.timeout(20000);
+			var tmpobj = tmp.dirSync();
+			var gitDir = tmpobj.name;
+			var gitCloneCmd = child.spawnSync(
+				"git", ["clone", test.gitCloneUrl, gitDir], {
+					cwd: gitDir
+				}
+			);
+			assert.deepEqual(gitCloneCmd.status, 0, gitCloneCmd.stderr);
+			var gitCheckoutCmd = child.spawnSync("git", ["checkout", test.branch], {
+				cwd: gitDir
+			});
+			assert.deepEqual(gitCheckoutCmd.status, 0, gitCheckoutCmd.stderr);
+			var changesetArgs = [fdt, "changeset", "create", "test"];
+			[].push.apply(changesetArgs, test.patterns);
+			var changesetCreateCmd = child.spawnSync(
+				"node", changesetArgs, {
+					cwd: gitDir
+				}
+			);
+			assert.deepEqual(
+				changesetCreateCmd.status,
+				0,
+				changesetCreateCmd.stdout
+			);
+			var diffDirsCmd = child.spawnSync(
+				"diff", [
+					"-u",
+					"-r",
+					path.join(gitDir, test.expected),
+					path.join(gitDir, "config", "deployments", "test")
+				], {
+					cwd: gitDir
+				}
+			);
+			assert.deepEqual(diffDirsCmd.status, 0, diffDirsCmd.stdout);
+		});
+	});
+});


### PR DESCRIPTION
Passing explicit patterns (e.g. `echo "" | force-dev-tool changeset create vat CustomField/Account.VAT_Number__c`) was broken since PR #99.
Note that this command currently requires an empty input like `echo ""`.

Fixes #131