### PR TITLE
feat: adding themes support

### DIFF
--- a/lib/describe-metadata-result.json
+++ b/lib/describe-metadata-result.json
@@ -632,7 +632,7 @@
 		"inFolder": false,
 		"metaFile": false,
 		"suffix": "lightningExperienceThemes",
-		"xmlName": "lightningExperienceTheme"
+		"xmlName": "LightningExperienceTheme"
 	}],
 	"organizationNamespace": "",
 	"partialSaveAllowed": true,


### PR DESCRIPTION

Adding metadata description for brandingSets and LightningExperienceThemes.

References:
- https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_brandingset.htm
- https://salesforce.stackexchange.com/questions/219356/how-to-retrieve-deploy-salesforce-lightning-theme-using-metadata-api
