### PR TITLE
fix: pin event-stream to 3.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1902,8 +1901,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "map-stream": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "async": "^2.6.0",
     "chalk": "^2.3.0",
     "docopt": "^0.6.2",
-    "event-stream": "^3.3.4",
+    "event-stream": "3.3.4",
     "find-up": "^3.0.0",
     "fs-extra": "^6.0.1",
     "glob": "^7.0.6",


### PR DESCRIPTION
The `event-stream` package has been compromised
(see https://github.com/dominictarr/event-stream/issues/116).

This pins the dependency `event-stream` to the exact version `3.3.4`
to prevent updating.