### PR TITLE
fix: implement PermissionSet v40 behavior

### DIFF
--- a/lib/describe-metadata-service.js
+++ b/lib/describe-metadata-service.js
@@ -3,7 +3,6 @@
 var _ = require('underscore');
 var path = require('path');
 
-// TODO: this should be parsed from Metadata WSDL
 var childTypes = [{
 	xmlName: 'ActionOverride',
 	tagName: 'actionOverrides',
@@ -151,56 +150,6 @@ var childTypes = [{
 	key: 'fullName',
 	isNamed: true,
 	notCustomObjectRelated: true
-}, {
-	xmlName: 'PermissionSetApplicationVisibility',
-	tagName: 'applicationVisibilities',
-	parent: 'PermissionSet',
-	key: 'application'
-}, {
-	xmlName: 'PermissionSetApexClassAccess',
-	tagName: 'classAccesses',
-	parent: 'PermissionSet',
-	key: 'apexClass'
-}, {
-	xmlName: 'PermissionSetApexPageAccess',
-	tagName: 'pageAccesses',
-	parent: 'PermissionSet',
-	key: 'apexPage'
-}, {
-	xmlName: 'PermissionSetCustomPermissions',
-	tagName: 'customPermissions',
-	parent: 'PermissionSet',
-	key: 'name'
-}, {
-	xmlName: 'PermissionSetExternalDataSourceAccess',
-	tagName: 'externalDataSourceAccesses',
-	parent: 'PermissionSet',
-	key: 'externalDataSource'
-}, {
-	xmlName: 'PermissionSetFieldPermissions',
-	tagName: 'fieldPermissions',
-	parent: 'PermissionSet',
-	key: 'field'
-}, {
-	xmlName: 'PermissionSetObjectPermissions',
-	tagName: 'objectPermissions',
-	parent: 'PermissionSet',
-	key: 'object'
-}, {
-	xmlName: 'PermissionSetRecordTypeVisibility',
-	tagName: 'recordTypeVisibilities',
-	parent: 'PermissionSet',
-	key: 'recordType'
-}, {
-	xmlName: 'PermissionSetTabSetting',
-	tagName: 'tabSettings',
-	parent: 'PermissionSet',
-	key: 'tab'
-}, {
-	xmlName: 'PermissionSetUserPermission',
-	tagName: 'userPermissions',
-	parent: 'PermissionSet',
-	key: 'name'
 }, {
 	xmlName: 'ProfileApplicationVisibility',
 	tagName: 'applicationVisibilities',

--- a/test-integration/changeset.js
+++ b/test-integration/changeset.js
@@ -58,8 +58,7 @@ var tests = [{
 		a: "HEAD^{/v0:}",
 		b: "HEAD",
 		unpackaged_path: "src",
-		expected: path.join("config", "deployments", "expected"),
-		skip: true
+		expected: path.join("config", "deployments", "expected")
 	}
 ];
 


### PR DESCRIPTION
Treat PermissionSets as whole files when creating changesets.

Fixes #89.