### PR TITLE
fix: add all files for LightningComponentBundle

### DIFF
--- a/lib/metadata-container.js
+++ b/lib/metadata-container.js
@@ -262,8 +262,8 @@ MetadataContainer.prototype.completeMetadataWith = function(opts) {
 					var stat = fs.statSync(realPath);
 					var relativePaths = [];
 					if (stat.isDirectory()) {
-						// add all files in that directory in case of AuraDefinitionBundle or a WaveTemplate
-						if (filename.indexOf('aura') === 0 || filename.indexOf('waveTemplates') === 0) {
+						// add all files in that directory in case of AuraDefinitionBundle or a WaveTemplate or LightningComponentBundle
+						if (filename.indexOf('aura') === 0 || filename.indexOf('waveTemplates') === 0 || filename.indexOf('lwc') === 0 ) {
 							var foo = listFilesInTree(realPath, filename);
 							relativePaths = flatten(foo);
 						}


### PR DESCRIPTION
Fixes issue with LightningComponentBundles so all files from the bundle are added to package when one file is changed (similar to Aura bundles)