### PR TITLE
feat: add support for LightningMessageChannel

### DIFF
--- a/lib/describe-metadata-result.json
+++ b/lib/describe-metadata-result.json
@@ -691,6 +691,12 @@
 		"metaFile": false,
 		"suffix": "notiftype",
 		"xmlName": "CustomNotificationType"
+	}, {
+		"directoryName": "messageChannels",
+		"inFolder": false,
+		"metaFile": false,
+		"suffix": "messageChannel",
+		"xmlName": "LightningMessageChannel"
 	}],
 	"organizationNamespace": "",
 	"partialSaveAllowed": true,


### PR DESCRIPTION
Adding support to meta_lightningmessagechannel, it is in Beta, but I need to add it.

The metadata reference link is:
https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_lightningmessagechannel.htm

Sample:

src/messageChannels/sample.messageChannel
```xml
<?xml version="1.0" encoding="UTF-8"?>
<LightningMessageChannel xmlns="http://soap.sforce.com/2006/04/metadata">
    <description>Lightning Message Channel Sample</description>
    <isExposed>true</isExposed>
    <lightningMessageFields>
        <description>Field Sample 1</description>
        <fieldName>recordId</fieldName>
    </lightningMessageFields>
    <lightningMessageFields>
        <description>Field Sample 2</description>
        <fieldName>debtorName</fieldName>
    </lightningMessageFields>
    <masterLabel>sample</masterLabel>
</LightningMessageChannel>
```

This resolves #223