### PR TITLE
feat: child xml required for Custom Object

### DIFF
--- a/lib/describe-metadata-result.json
+++ b/lib/describe-metadata-result.json
@@ -114,6 +114,13 @@
 			"ListView",
 			"FieldSet"
 		],
+		"childXmlRequired": [
+			"deploymentStatus",
+			"label",
+			"nameField",
+			"pluralLabel",
+			"sharingModel"
+		],
 		"directoryName": "objects",
 		"inFolder": false,
 		"metaFile": false,

--- a/lib/metadata-container.js
+++ b/lib/metadata-container.js
@@ -103,6 +103,7 @@ MetadataContainer.prototype.filter = function(manifest) {
 						}
 						containerFile.addComponent(c);
 					});
+					containerFile.childXmlRequired();
 					containerFile.writeContents();
 					filteredMetadataContainer.add(containerFile, []);
 				}

--- a/lib/metadata-file-container.js
+++ b/lib/metadata-file-container.js
@@ -7,6 +7,9 @@ var Manifest = require('./manifest');
 var MetadataComponent = require('./metadata-component');
 var MetadataUtils = require('./utils');
 var describeMetadataService = new(require('./describe-metadata-service'))();
+var process = require('process');
+var path = require('path');
+var fs = require('fs');
 
 // TODO: this represents the child of a MetadataFileContainer
 // though some components are not being listed in the manifest
@@ -160,6 +163,39 @@ MetadataFileContainer.prototype.addComponent = function(cmp) {
 // 	});
 // 	return filteredMetadataFileContainer;
 // };
+
+MetadataFileContainer.prototype.childXmlRequired = function() {
+	var self = this;
+	var childXmlRequired = self.getMetadataType().childXmlRequired;
+	if (childXmlRequired) {
+		var fullPath = path.join(process.cwd(), 'src', self.path);
+		if (fs.existsSync(fullPath)) {
+			var parsed = new xmldoc.XmlDocument(fs.readFileSync(fullPath));
+			childXmlRequired.map(function(childXml) {
+				var descendant = parsed.descendantWithPath(childXml);
+				if (descendant) {
+					var content = '    ' + parsed.descendantWithPath(childXml).toString({
+						compressed: true,
+						trimmed: false,
+						preserveWhitespace: !self.opts.ignoreWhitespace
+					});
+					var fullName = self.stem + '.' + childXml;
+					var exist = _.findWhere(self.components, {
+						fullName: fullName
+					});
+					if (!exist) {
+						self.addComponent(new MetadataFileComponent({
+							fullName: fullName,
+							type: childXml,
+							contents: content,
+							parent: self.getMetadataType()
+						}));
+					}
+				}
+			});
+		}
+	}
+}
 
 MetadataFileContainer.prototype.getGroupedAndSortedComponents = function() {
 	var self = this;


### PR DESCRIPTION
The change set in Custom Object must always contains the following xml properties:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
  ...
  change set
  ...
    <deploymentStatus>Deployed</deploymentStatus>
    <label>CustomObjectTest</label>
    <nameField>
        <label>CustomObjectTest Name</label>
        <type>Text</type>
    </nameField>
    <pluralLabel>CustomObjectTest</pluralLabel>
    <sharingModel>ReadWrite</sharingModel>
</CustomObject>
```
