### PR TITLE
feat: update list of metadata for changeset cmd

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,0 +1,18 @@
+{
+  "orgName": "me company",
+  "edition": "Developer",
+  "features": [],
+  "settings": {
+    "lightningExperienceSettings": {
+        "enableS1DesktopEnabled": true
+    },
+    "securitySettings": {
+        "passwordPolicies": {
+            "enableSetPasswordInApi": true
+        }
+    },
+    "mobileSettings": {
+        "enableS1EncryptedStoragePref2": false
+    }
+  }
+}

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,7 +1,7 @@
 {
   "orgName": "me company",
-  "edition": "Developer",
-  "features": [],
+  "edition": "Enterprise",
+  "features": ["Communities", "Entitlements", "EventLogFile", "FieldService", "Knowledge", "LiveAgent", "DevelopmentWave"],
   "settings": {
     "lightningExperienceSettings": {
         "enableS1DesktopEnabled": true
@@ -11,8 +11,17 @@
             "enableSetPasswordInApi": true
         }
     },
+    "languageSettings": {
+        "enableTranslationWorkbench": true
+    },
     "mobileSettings": {
         "enableS1EncryptedStoragePref2": false
+    },
+    "liveAgentSettings": {
+        "enableLiveAgent": true
+    },
+    "communitiesSettings": {
+        "enableNetworksEnabled": true
     }
   }
 }

--- a/lib/describe-metadata-result.json
+++ b/lib/describe-metadata-result.json
@@ -14,6 +14,13 @@
 			"xmlName": "AnalyticSnapshot"
 		},
 		{
+			"directoryName": "animationRules",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "animationRule",
+			"xmlName": "AnimationRule"
+		},
+		{
 			"directoryName": "classes",
 			"inFolder": false,
 			"metaFile": true,
@@ -26,6 +33,13 @@
 			"metaFile": true,
 			"suffix": "component",
 			"xmlName": "ApexComponent"
+		},
+		{
+			"directoryName": "apexEmailNotifications",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "notifications",
+			"xmlName": "ApexEmailNotifications"
 		},
 		{
 			"directoryName": "pages",
@@ -73,6 +87,13 @@
 			"xmlName": "AssignmentRules"
 		},
 		{
+			"directoryName": "audience",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "audience",
+			"xmlName": "Audience"
+		},
+		{
 			"directoryName": "aura",
 			"inFolder": false,
 			"metaFile": false,
@@ -96,6 +117,13 @@
 			"xmlName": "AutoResponseRules"
 		},
 		{
+			"directoryName": "blacklistedConsumers",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "blacklistedConsumer",
+			"xmlName": "BlacklistedConsumer"
+		},
+		{
 			"directoryName": "brandingSets",
 			"inFolder": false,
 			"metaFile": false,
@@ -103,11 +131,39 @@
 			"xmlName": "BrandingSet"
 		},
 		{
+			"directoryName": "cmsConnectSource",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "cmsConnectSource",
+			"xmlName": "CMSConnectSource"
+		},
+		{
 			"directoryName": "callCenters",
 			"inFolder": false,
 			"metaFile": false,
 			"suffix": "callCenter",
 			"xmlName": "CallCenter"
+		},
+		{
+			"directoryName": "callCoachingMediaProviders",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "callCoachingMediaProvider",
+			"xmlName": "CallCoachingMediaProvider"
+		},
+		{
+			"directoryName": "Canvases",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "Canvas",
+			"xmlName": "CanvasMetadata"
+		},
+		{
+			"directoryName": "CaseSubjectParticles",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "CaseSubjectParticle",
+			"xmlName": "CaseSubjectParticle"
 		},
 		{
 			"directoryName": "certs",
@@ -122,6 +178,13 @@
 			"metaFile": false,
 			"suffix": "channelLayout",
 			"xmlName": "ChannelLayout"
+		},
+		{
+			"directoryName": "ChatterExtensions",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "ChatterExtension",
+			"xmlName": "ChatterExtension"
 		},
 		{
 			"directoryName": "cleanDataServices",
@@ -173,6 +236,13 @@
 			"xmlName": "CorsWhitelistOrigin"
 		},
 		{
+			"directoryName": "cspTrustedSites",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "cspTrustedSite",
+			"xmlName": "CspTrustedSite"
+		},
+		{
 			"directoryName": "applications",
 			"inFolder": false,
 			"metaFile": false,
@@ -192,6 +262,13 @@
 			"metaFile": false,
 			"suffix": "feedFilter",
 			"xmlName": "CustomFeedFilter"
+		},
+		{
+			"directoryName": "customHelpMenuSections",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "customHelpMenuSection",
+			"xmlName": "CustomHelpMenuSection"
 		},
 		{
 			"childXmlNames": [
@@ -220,9 +297,10 @@
 		{
 			"childXmlNames": [
 				"CustomField",
+				"Index",
 				"BusinessProcess",
-				"CompactLayout",
 				"RecordType",
+				"CompactLayout",
 				"WebLink",
 				"ValidationRule",
 				"SharingReason",
@@ -305,11 +383,32 @@
 			"xmlName": "DuplicateRule"
 		},
 		{
+			"directoryName": "eclair",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "geodata",
+			"xmlName": "EclairGeoData"
+		},
+		{
+			"directoryName": "emailservices",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "xml",
+			"xmlName": "EmailServicesFunction"
+		},
+		{
 			"directoryName": "email",
 			"inFolder": true,
 			"metaFile": true,
 			"suffix": "email",
 			"xmlName": "EmailTemplate"
+		},
+		{
+			"directoryName": "EmbeddedServiceBranding",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "EmbeddedServiceBranding",
+			"xmlName": "EmbeddedServiceBranding"
 		},
 		{
 			"directoryName": "EmbeddedServiceConfig",
@@ -319,11 +418,25 @@
 			"xmlName": "EmbeddedServiceConfig"
 		},
 		{
+			"directoryName": "EmbeddedServiceFlowConfig",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "EmbeddedServiceFlowConfig",
+			"xmlName": "EmbeddedServiceFlowConfig"
+		},
+		{
 			"directoryName": "EmbeddedServiceLiveAgent",
 			"inFolder": false,
 			"metaFile": false,
 			"suffix": "EmbeddedServiceLiveAgent",
 			"xmlName": "EmbeddedServiceLiveAgent"
+		},
+		{
+			"directoryName": "EmbeddedServiceMenuSettings",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "EmbeddedServiceMenuSettings",
+			"xmlName": "EmbeddedServiceMenuSettings"
 		},
 		{
 			"directoryName": "entitlementProcesses",
@@ -357,6 +470,13 @@
 			"xmlName": "ExternalDataSource"
 		},
 		{
+			"directoryName": "externalServiceRegistrations",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "externalServiceRegistration",
+			"xmlName": "ExternalServiceRegistration"
+		},
+		{
 			"directoryName": "flexipages",
 			"inFolder": false,
 			"metaFile": false,
@@ -369,6 +489,13 @@
 			"metaFile": false,
 			"suffix": "flow",
 			"xmlName": "Flow"
+		},
+		{
+			"directoryName": "flowCategories",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "flowCategory",
+			"xmlName": "FlowCategory"
 		},
 		{
 			"directoryName": "flowDefinitions",
@@ -413,6 +540,20 @@
 			"xmlName": "HomePageLayout"
 		},
 		{
+			"directoryName": "iframeWhiteListUrlSettings",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "iframeWhiteListUrlSettings",
+			"xmlName": "IframeWhiteListUrlSettings"
+		},
+		{
+			"directoryName": "inboundNetworkConnections",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "inboundNetworkConnection",
+			"xmlName": "InboundNetworkConnection"
+		},
+		{
 			"directoryName": "installedPackages",
 			"inFolder": false,
 			"metaFile": false,
@@ -434,11 +575,25 @@
 			"xmlName": "Layout"
 		},
 		{
+			"directoryName": "LeadConvertSettings",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "LeadConvertSetting",
+			"xmlName": "LeadConvertSettings"
+		},
+		{
 			"directoryName": "letterhead",
 			"inFolder": false,
 			"metaFile": false,
 			"suffix": "letter",
 			"xmlName": "Letterhead"
+		},
+		{
+			"directoryName": "lightningBolts",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "lightningBolt",
+			"xmlName": "LightningBolt"
 		},
 		{
 			"directoryName": "lwc",
@@ -459,6 +614,13 @@
 			"metaFile": false,
 			"suffix": "messageChannel",
 			"xmlName": "LightningMessageChannel"
+		},
+		{
+			"directoryName": "lightningOnboardingConfigs",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "lightningOnboardingConfig",
+			"xmlName": "LightningOnboardingConfig"
 		},
 		{
 			"directoryName": "liveChatAgentConfigs",
@@ -489,6 +651,13 @@
 			"xmlName": "LiveChatSensitiveDataRule"
 		},
 		{
+			"directoryName": "managedContentTypes",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "managedContentType",
+			"xmlName": "ManagedContentType"
+		},
+		{
 			"childXmlNames": [
 				"ManagedTopic"
 			],
@@ -516,11 +685,32 @@
 			"xmlName": "MilestoneType"
 		},
 		{
+			"directoryName": "MobileApplicationDetails",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "MobileApplicationDetail",
+			"xmlName": "MobileApplicationDetail"
+		},
+		{
 			"directoryName": "moderation",
 			"inFolder": false,
 			"metaFile": false,
 			"suffix": "rule",
 			"xmlName": "ModerationRule"
+		},
+		{
+			"directoryName": "mutingpermissionsets",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "mutingpermissionset",
+			"xmlName": "MutingPermissionSet"
+		},
+		{
+			"directoryName": "myDomainDiscoverableLogins",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "myDomainDiscoverableLogin",
+			"xmlName": "MyDomainDiscoverableLogin"
 		},
 		{
 			"directoryName": "namedCredentials",
@@ -530,11 +720,46 @@
 			"xmlName": "NamedCredential"
 		},
 		{
+			"directoryName": "navigationMenus",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "navigationMenu",
+			"xmlName": "NavigationMenu"
+		},
+		{
 			"directoryName": "networks",
 			"inFolder": false,
 			"metaFile": false,
 			"suffix": "network",
 			"xmlName": "Network"
+		},
+		{
+			"directoryName": "networkBranding",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "networkBranding",
+			"xmlName": "NetworkBranding"
+		},
+		{
+			"directoryName": "notificationTypeConfig",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "config",
+			"xmlName": "NotificationTypeConfig"
+		},
+		{
+			"directoryName": "oauthcustomscopes",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "oauthcustomscope",
+			"xmlName": "OauthCustomScope"
+		},
+		{
+			"directoryName": "outboundNetworkConnections",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "outboundNetworkConnection",
+			"xmlName": "OutboundNetworkConnection"
 		},
 		{
 			"directoryName": "pathAssistants",
@@ -551,11 +776,32 @@
 			"xmlName": "PermissionSet"
 		},
 		{
+			"directoryName": "permissionsetgroups",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "permissionsetgroup",
+			"xmlName": "PermissionSetGroup"
+		},
+		{
 			"directoryName": "cachePartitions",
 			"inFolder": false,
 			"metaFile": false,
 			"suffix": "cachePartition",
 			"xmlName": "PlatformCachePartition"
+		},
+		{
+			"directoryName": "platformEventChannels",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "platformEventChannel",
+			"xmlName": "PlatformEventChannel"
+		},
+		{
+			"directoryName": "platformEventChannelMembers",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "platformEventChannelMember",
+			"xmlName": "PlatformEventChannelMember"
 		},
 		{
 			"directoryName": "portals",
@@ -614,6 +860,27 @@
 			"xmlName": "QuickAction"
 		},
 		{
+			"directoryName": "recommendationStrategies",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "recommendationStrategy",
+			"xmlName": "RecommendationStrategy"
+		},
+		{
+			"directoryName": "recordActionDeployments",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "deployment",
+			"xmlName": "RecordActionDeployment"
+		},
+		{
+			"directoryName": "redirectWhitelistUrls",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "redirectWhitelistUrl",
+			"xmlName": "RedirectWhitelistUrl"
+		},
+		{
 			"directoryName": "remoteSiteSettings",
 			"inFolder": false,
 			"metaFile": false,
@@ -665,7 +932,8 @@
 		{
 			"childXmlNames": [
 				"SharingOwnerRule",
-				"SharingCriteriaRule"
+				"SharingCriteriaRule",
+				"SharingGuestRule"
 			],
 			"directoryName": "sharingRules",
 			"inFolder": false,
@@ -723,6 +991,13 @@
 			"xmlName": "SynonymDictionary"
 		},
 		{
+			"directoryName": "topicsForObjects",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "topicsForObjects",
+			"xmlName": "TopicsForObjects"
+		},
+		{
 			"directoryName": "transactionSecurityPolicies",
 			"inFolder": false,
 			"metaFile": false,
@@ -742,6 +1017,13 @@
 			"metaFile": false,
 			"suffix": "userCriteria",
 			"xmlName": "UserCriteria"
+		},
+		{
+			"directoryName": "userProvisioningConfigs",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "userProvisioningConfig",
+			"xmlName": "UserProvisioningConfig"
 		},
 		{
 			"directoryName": "wave",

--- a/lib/describe-metadata-result.json
+++ b/lib/describe-metadata-result.json
@@ -1,709 +1,820 @@
 {
 	"metadataObjects": [{
-		"directoryName": "installedPackages",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "installedPackage",
-		"xmlName": "InstalledPackage"
-	}, {
-		"childXmlNames": [
-			"CustomLabel"
-		],
-		"directoryName": "labels",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "labels",
-		"xmlName": "CustomLabels"
-	}, {
-		"directoryName": "staticresources",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "resource",
-		"xmlName": "StaticResource"
-	}, {
-		"directoryName": "scontrols",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "scf",
-		"xmlName": "Scontrol"
-	}, {
-		"directoryName": "certs",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "crt",
-		"xmlName": "Certificate"
-	}, {
-		"directoryName": "aura",
-		"inFolder": false,
-		"metaFile": false,
-		"xmlName": "AuraDefinitionBundle"
-	}, {
-		"directoryName": "components",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "component",
-		"xmlName": "ApexComponent"
-	}, {
-		"directoryName": "pages",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "page",
-		"xmlName": "ApexPage"
-	}, {
-		"directoryName": "queues",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "queue",
-		"xmlName": "Queue"
-	}, {
-		"directoryName": "dataSources",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "dataSource",
-		"xmlName": "ExternalDataSource"
-	}, {
-		"directoryName": "lwc",
-		"inFolder": false,
-		"metaFile": false,
-		"xmlName": "LightningComponentBundle"
-	},{
-		"directoryName": "namedCredentials",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "namedCredential",
-		"xmlName": "NamedCredential"
-	}, {
-		"directoryName": "roles",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "role",
-		"xmlName": "Role"
-	}, {
-		"directoryName": "groups",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "group",
-		"xmlName": "Group"
-	}, {
-		"directoryName": "globalValueSets",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "globalValueSet",
-		"xmlName": "GlobalValueSet"
-	}, {
-		"directoryName": "standardValueSets",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "standardValueSet",
-		"xmlName": "StandardValueSet"
-	}, {
-		"directoryName": "customPermissions",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "customPermission",
-		"xmlName": "CustomPermission"
-	}, {
-		"childXmlNames": [
-			"CustomField",
-			"BusinessProcess",
-			"CompactLayout",
-			"RecordType",
-			"WebLink",
-			"ValidationRule",
-			"SharingReason",
-			"ListView",
-			"FieldSet"
-		],
-		"directoryName": "objects",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "object",
-		"xmlName": "CustomObject"
-	}, {
-		"directoryName": "reportTypes",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "reportType",
-		"xmlName": "ReportType"
-	}, {
-		"directoryName": "reports",
-		"inFolder": true,
-		"metaFile": false,
-		"suffix": "report",
-		"xmlName": "Report"
-	}, {
-		"directoryName": "dashboards",
-		"inFolder": true,
-		"metaFile": false,
-		"suffix": "dashboard",
-		"xmlName": "Dashboard"
-	}, {
-		"directoryName": "analyticSnapshots",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "snapshot",
-		"xmlName": "AnalyticSnapshot"
-	}, {
-		"directoryName": "feedFilters",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "feedFilter",
-		"xmlName": "CustomFeedFilter"
-	}, {
-		"directoryName": "layouts",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "layout",
-		"xmlName": "Layout"
-	}, {
-		"directoryName": "documents",
-		"inFolder": true,
-		"metaFile": true,
-		"xmlName": "Document"
-	}, {
-		"directoryName": "weblinks",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "weblink",
-		"xmlName": "CustomPageWebLink"
-	}, {
-		"directoryName": "letterhead",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "letter",
-		"xmlName": "Letterhead"
-	}, {
-		"directoryName": "email",
-		"inFolder": true,
-		"metaFile": true,
-		"suffix": "email",
-		"xmlName": "EmailTemplate"
-	}, {
-		"directoryName": "quickActions",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "quickAction",
-		"xmlName": "QuickAction"
-	}, {
-		"directoryName": "flexipages",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "flexipage",
-		"xmlName": "FlexiPage"
-	}, {
-		"directoryName": "tabs",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "tab",
-		"xmlName": "CustomTab"
-	}, {
-		"directoryName": "customApplicationComponents",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "customApplicationComponent",
-		"xmlName": "CustomApplicationComponent"
-	}, {
-		"directoryName": "applications",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "app",
-		"xmlName": "CustomApplication"
-	}, {
-		"directoryName": "portals",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "portal",
-		"xmlName": "Portal"
-	}, {
-		"directoryName": "EmbeddedServiceConfig",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "EmbeddedServiceConfig",
-		"xmlName": "EmbeddedServiceConfig"
-	}, {
-		"directoryName": "EmbeddedServiceLiveAgent",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "EmbeddedServiceLiveAgent",
-		"xmlName": "EmbeddedServiceLiveAgent"
-	}, {
-		"directoryName": "flows",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "flow",
-		"xmlName": "Flow"
-	}, {
-		"directoryName": "flowDefinitions",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "flowDefinition",
-		"xmlName": "FlowDefinition"
-	}, {
-		"childXmlNames": [
-			"WorkflowFieldUpdate",
-			"WorkflowKnowledgePublish",
-			"WorkflowTask",
-			"WorkflowAlert",
-			"WorkflowSend",
-			"WorkflowOutboundMessage",
-			"WorkflowRule"
-		],
-		"directoryName": "workflows",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "workflow",
-		"xmlName": "Workflow"
-	}, {
-		"childXmlNames": [
-			"AssignmentRule"
-		],
-		"directoryName": "assignmentRules",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "assignmentRules",
-		"xmlName": "AssignmentRules"
-	}, {
-		"childXmlNames": [
-			"AutoResponseRule"
-		],
-		"directoryName": "autoResponseRules",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "autoResponseRules",
-		"xmlName": "AutoResponseRules"
-	}, {
-		"childXmlNames": [
-			"EscalationRule"
-		],
-		"directoryName": "escalationRules",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "escalationRules",
-		"xmlName": "EscalationRules"
-	}, {
-		"directoryName": "postTemplates",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "postTemplate",
-		"xmlName": "PostTemplate"
-	}, {
-		"directoryName": "approvalProcesses",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "approvalProcess",
-		"xmlName": "ApprovalProcess"
-	}, {
-		"directoryName": "homePageComponents",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "homePageComponent",
-		"xmlName": "HomePageComponent"
-	}, {
-		"directoryName": "homePageLayouts",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "homePageLayout",
-		"xmlName": "HomePageLayout"
-	}, {
-		"directoryName": "objectTranslations",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "objectTranslation",
-		"xmlName": "CustomObjectTranslation"
-	}, {
-		"directoryName": "translations",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "translation",
-		"xmlName": "Translations"
-	}, {
-		"directoryName": "globalValueSetTranslations",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "globalValueSetTranslation",
-		"xmlName": "GlobalValueSetTranslation"
-	}, {
-		"directoryName": "standardValueSetTranslations",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "standardValueSetTranslation",
-		"xmlName": "StandardValueSetTranslation"
-	}, {
-		"directoryName": "classes",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "cls",
-		"xmlName": "ApexClass"
-	}, {
-		"directoryName": "triggers",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "trigger",
-		"xmlName": "ApexTrigger"
-	}, {
-		"directoryName": "testSuites",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "testSuite",
-		"xmlName": "ApexTestSuite"
-	}, {
-		"directoryName": "profiles",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "profile",
-		"xmlName": "Profile"
-	}, {
-		"directoryName": "permissionsets",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "permissionset",
-		"xmlName": "PermissionSet"
-	}, {
-		"directoryName": "customMetadata",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "md",
-		"xmlName": "CustomMetadata"
-	}, {
-		"directoryName": "profilePasswordPolicies",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "profilePasswordPolicy",
-		"xmlName": "ProfilePasswordPolicy"
-	}, {
-		"directoryName": "profileSessionSettings",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "profileSessionSetting",
-		"xmlName": "ProfileSessionSetting"
-	}, {
-		"directoryName": "datacategorygroups",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "datacategorygroup",
-		"xmlName": "DataCategoryGroup"
-	}, {
-		"directoryName": "remoteSiteSettings",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "remoteSite",
-		"xmlName": "RemoteSiteSetting"
-	}, {
-		"childXmlNames": [
-			"MatchingRule"
-		],
-		"directoryName": "matchingRules",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "matchingRule",
-		"xmlName": "MatchingRules"
-	}, {
-		"directoryName": "duplicateRules",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "duplicateRule",
-		"xmlName": "DuplicateRule"
-	}, {
-		"directoryName": "cleanDataServices",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "cleanDataService",
-		"xmlName": "CleanDataService"
-	}, {
-		"directoryName": "authproviders",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "authprovider",
-		"xmlName": "AuthProvider"
-	}, {
-		"directoryName": "sites",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "site",
-		"xmlName": "CustomSite"
-	}, {
-		"directoryName": "channelLayouts",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "channelLayout",
-		"xmlName": "ChannelLayout"
-	}, {
-		"directoryName": "contentassets",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "asset",
-		"xmlName": "ContentAsset"
-	}, {
-		"childXmlNames": [
-			"SharingOwnerRule",
-			"SharingCriteriaRule"
-		],
-		"directoryName": "sharingRules",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "sharingRules",
-		"xmlName": "SharingRules"
-	}, {
-		"directoryName": "sharingSets",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "sharingSet",
-		"xmlName": "SharingSet"
-	}, {
-		"directoryName": "communities",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "community",
-		"xmlName": "Community"
-	}, {
-		"directoryName": "callCenters",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "callCenter",
-		"xmlName": "CallCenter"
-	}, {
-		"directoryName": "milestoneTypes",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "milestoneType",
-		"xmlName": "MilestoneType"
-	}, {
-		"directoryName": "entitlementProcesses",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "entitlementProcess",
-		"xmlName": "EntitlementProcess"
-	}, {
-		"directoryName": "entitlementTemplates",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "entitlementTemplate",
-		"xmlName": "EntitlementTemplate"
-	}, {
-		"directoryName": "connectedApps",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "connectedApp",
-		"xmlName": "ConnectedApp"
-	}, {
-		"directoryName": "appMenus",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "appMenu",
-		"xmlName": "AppMenu"
-	}, {
-		"directoryName": "delegateGroups",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "delegateGroup",
-		"xmlName": "DelegateGroup"
-	}, {
-		"directoryName": "siteDotComSites",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "site",
-		"xmlName": "SiteDotCom"
-	}, {
-		"directoryName": "networks",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "network",
-		"xmlName": "Network"
-	}, {
-		"directoryName": "communityThemeDefinitions",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "communityThemeDefinition",
-		"xmlName": "CommunityThemeDefinition"
-	}, {
-		"directoryName": "communityTemplateDefinitions",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "communityTemplateDefinition",
-		"xmlName": "CommunityTemplateDefinition"
-	}, {
-		"childXmlNames": [
-			"ManagedTopic"
-		],
-		"directoryName": "managedTopics",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "managedTopics",
-		"xmlName": "ManagedTopics"
-	}, {
-		"directoryName": "moderation",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "keywords",
-		"xmlName": "KeywordList"
-	}, {
-		"directoryName": "userCriteria",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "userCriteria",
-		"xmlName": "UserCriteria"
-	}, {
-		"directoryName": "moderation",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "rule",
-		"xmlName": "ModerationRule"
-	}, {
-		"directoryName": "samlssoconfigs",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "samlssoconfig",
-		"xmlName": "SamlSsoConfig"
-	}, {
-		"directoryName": "corsWhitelistOrigins",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "corsWhitelistOrigin",
-		"xmlName": "CorsWhitelistOrigin"
-	}, {
-		"directoryName": "actionLinkGroupTemplates",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "actionLinkGroupTemplate",
-		"xmlName": "ActionLinkGroupTemplate"
-	}, {
-		"directoryName": "transactionSecurityPolicies",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "transactionSecurityPolicy",
-		"xmlName": "TransactionSecurityPolicy"
-	}, {
-		"directoryName": "skills",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "skill",
-		"xmlName": "Skill"
-	}, {
-		"directoryName": "liveChatDeployments",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "liveChatDeployment",
-		"xmlName": "LiveChatDeployment"
-	}, {
-		"directoryName": "liveChatButtons",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "liveChatButton",
-		"xmlName": "LiveChatButton"
-	}, {
-		"directoryName": "liveChatAgentConfigs",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "liveChatAgentConfig",
-		"xmlName": "LiveChatAgentConfig"
-	}, {
-		"directoryName": "synonymDictionaries",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "synonymDictionary",
-		"xmlName": "SynonymDictionary"
-	}, {
-		"directoryName": "pathAssistants",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "pathAssistant",
-		"xmlName": "PathAssistant"
-	}, {
-		"directoryName": "liveChatSensitiveDataRule",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "liveChatSensitiveDataRule",
-		"xmlName": "LiveChatSensitiveDataRule"
-	}, {
-		"directoryName": "cachePartitions",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "cachePartition",
-		"xmlName": "PlatformCachePartition"
-	}, {
-		"directoryName": "settings",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "settings",
-		"xmlName": "Settings"
-	}, {
-		"directoryName": "brandingSets",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "brandingSet",
-		"xmlName": "BrandingSet"
-	}, {
-		"directoryName": "wave",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "wapp",
-		"xmlName": "WaveApplication"
-	}, {
-		"directoryName": "wave",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "wdash",
-		"xmlName": "WaveDashboard"
-	}, {
-		"directoryName": "wave",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "wdf",
-		"xmlName": "WaveDataflow"
-	}, {
-		"directoryName": "wave",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "wds",
-		"xmlName": "WaveDataset"
-	}, {
-		"directoryName": "wave",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "wlens",
-		"xmlName": "WaveLens"
-	}, {
-		"directoryName": "wave",
-		"inFolder": false,
-		"metaFile": true,
-		"suffix": "wdpr",
-		"xmlName": "WaveRecipe"
-	}, {
-		"directoryName": "waveTemplates",
-		"inFolder": false,
-		"metaFile": false,
-		"xmlName": "WaveTemplateBundle"
-	}, {
-		"directoryName": "wave",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "xmd",
-		"xmlName": "WaveXmd"
-	}, {
-		"directoryName": "lightningExperienceThemes",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "lightningExperienceTheme",
-		"xmlName": "LightningExperienceTheme"
-	}, {
-		"directoryName": "notificationtypes",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "notiftype",
-		"xmlName": "CustomNotificationType"
-	}, {
-		"directoryName": "messageChannels",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "messageChannel",
-		"xmlName": "LightningMessageChannel"
-	}, {
-		"directoryName": "prompts",
-		"inFolder": false,
-		"metaFile": false,
-		"suffix": "prompt",
-		"xmlName": "Prompt"
-	}],
+			"directoryName": "actionLinkGroupTemplates",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "actionLinkGroupTemplate",
+			"xmlName": "ActionLinkGroupTemplate"
+		},
+		{
+			"directoryName": "analyticSnapshots",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "snapshot",
+			"xmlName": "AnalyticSnapshot"
+		},
+		{
+			"directoryName": "classes",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "cls",
+			"xmlName": "ApexClass"
+		},
+		{
+			"directoryName": "components",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "component",
+			"xmlName": "ApexComponent"
+		},
+		{
+			"directoryName": "pages",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "page",
+			"xmlName": "ApexPage"
+		},
+		{
+			"directoryName": "testSuites",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "testSuite",
+			"xmlName": "ApexTestSuite"
+		},
+		{
+			"directoryName": "triggers",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "trigger",
+			"xmlName": "ApexTrigger"
+		},
+		{
+			"directoryName": "appMenus",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "appMenu",
+			"xmlName": "AppMenu"
+		},
+		{
+			"directoryName": "approvalProcesses",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "approvalProcess",
+			"xmlName": "ApprovalProcess"
+		},
+		{
+			"childXmlNames": [
+				"AssignmentRule"
+			],
+			"directoryName": "assignmentRules",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "assignmentRules",
+			"xmlName": "AssignmentRules"
+		},
+		{
+			"directoryName": "aura",
+			"inFolder": false,
+			"metaFile": false,
+			"xmlName": "AuraDefinitionBundle"
+		},
+		{
+			"directoryName": "authproviders",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "authprovider",
+			"xmlName": "AuthProvider"
+		},
+		{
+			"childXmlNames": [
+				"AutoResponseRule"
+			],
+			"directoryName": "autoResponseRules",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "autoResponseRules",
+			"xmlName": "AutoResponseRules"
+		},
+		{
+			"directoryName": "brandingSets",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "brandingSet",
+			"xmlName": "BrandingSet"
+		},
+		{
+			"directoryName": "callCenters",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "callCenter",
+			"xmlName": "CallCenter"
+		},
+		{
+			"directoryName": "certs",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "crt",
+			"xmlName": "Certificate"
+		},
+		{
+			"directoryName": "channelLayouts",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "channelLayout",
+			"xmlName": "ChannelLayout"
+		},
+		{
+			"directoryName": "cleanDataServices",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "cleanDataService",
+			"xmlName": "CleanDataService"
+		},
+		{
+			"directoryName": "communities",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "community",
+			"xmlName": "Community"
+		},
+		{
+			"directoryName": "communityTemplateDefinitions",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "communityTemplateDefinition",
+			"xmlName": "CommunityTemplateDefinition"
+		},
+		{
+			"directoryName": "communityThemeDefinitions",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "communityThemeDefinition",
+			"xmlName": "CommunityThemeDefinition"
+		},
+		{
+			"directoryName": "connectedApps",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "connectedApp",
+			"xmlName": "ConnectedApp"
+		},
+		{
+			"directoryName": "contentassets",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "asset",
+			"xmlName": "ContentAsset"
+		},
+		{
+			"directoryName": "corsWhitelistOrigins",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "corsWhitelistOrigin",
+			"xmlName": "CorsWhitelistOrigin"
+		},
+		{
+			"directoryName": "applications",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "app",
+			"xmlName": "CustomApplication"
+		},
+		{
+			"directoryName": "customApplicationComponents",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "customApplicationComponent",
+			"xmlName": "CustomApplicationComponent"
+		},
+		{
+			"directoryName": "feedFilters",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "feedFilter",
+			"xmlName": "CustomFeedFilter"
+		},
+		{
+			"childXmlNames": [
+				"CustomLabel"
+			],
+			"directoryName": "labels",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "labels",
+			"xmlName": "CustomLabels"
+		},
+		{
+			"directoryName": "customMetadata",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "md",
+			"xmlName": "CustomMetadata"
+		},
+		{
+			"directoryName": "notificationtypes",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "notiftype",
+			"xmlName": "CustomNotificationType"
+		},
+		{
+			"childXmlNames": [
+				"CustomField",
+				"BusinessProcess",
+				"CompactLayout",
+				"RecordType",
+				"WebLink",
+				"ValidationRule",
+				"SharingReason",
+				"ListView",
+				"FieldSet"
+			],
+			"directoryName": "objects",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "object",
+			"xmlName": "CustomObject"
+		},
+		{
+			"directoryName": "objectTranslations",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "objectTranslation",
+			"xmlName": "CustomObjectTranslation"
+		},
+		{
+			"directoryName": "weblinks",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "weblink",
+			"xmlName": "CustomPageWebLink"
+		},
+		{
+			"directoryName": "customPermissions",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "customPermission",
+			"xmlName": "CustomPermission"
+		},
+		{
+			"directoryName": "sites",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "site",
+			"xmlName": "CustomSite"
+		},
+		{
+			"directoryName": "tabs",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "tab",
+			"xmlName": "CustomTab"
+		},
+		{
+			"directoryName": "dashboards",
+			"inFolder": true,
+			"metaFile": false,
+			"suffix": "dashboard",
+			"xmlName": "Dashboard"
+		},
+		{
+			"directoryName": "datacategorygroups",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "datacategorygroup",
+			"xmlName": "DataCategoryGroup"
+		},
+		{
+			"directoryName": "delegateGroups",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "delegateGroup",
+			"xmlName": "DelegateGroup"
+		},
+		{
+			"directoryName": "documents",
+			"inFolder": true,
+			"metaFile": true,
+			"xmlName": "Document"
+		},
+		{
+			"directoryName": "duplicateRules",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "duplicateRule",
+			"xmlName": "DuplicateRule"
+		},
+		{
+			"directoryName": "email",
+			"inFolder": true,
+			"metaFile": true,
+			"suffix": "email",
+			"xmlName": "EmailTemplate"
+		},
+		{
+			"directoryName": "EmbeddedServiceConfig",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "EmbeddedServiceConfig",
+			"xmlName": "EmbeddedServiceConfig"
+		},
+		{
+			"directoryName": "EmbeddedServiceLiveAgent",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "EmbeddedServiceLiveAgent",
+			"xmlName": "EmbeddedServiceLiveAgent"
+		},
+		{
+			"directoryName": "entitlementProcesses",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "entitlementProcess",
+			"xmlName": "EntitlementProcess"
+		},
+		{
+			"directoryName": "entitlementTemplates",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "entitlementTemplate",
+			"xmlName": "EntitlementTemplate"
+		},
+		{
+			"childXmlNames": [
+				"EscalationRule"
+			],
+			"directoryName": "escalationRules",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "escalationRules",
+			"xmlName": "EscalationRules"
+		},
+		{
+			"directoryName": "dataSources",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "dataSource",
+			"xmlName": "ExternalDataSource"
+		},
+		{
+			"directoryName": "flexipages",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "flexipage",
+			"xmlName": "FlexiPage"
+		},
+		{
+			"directoryName": "flows",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "flow",
+			"xmlName": "Flow"
+		},
+		{
+			"directoryName": "flowDefinitions",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "flowDefinition",
+			"xmlName": "FlowDefinition"
+		},
+		{
+			"directoryName": "globalValueSets",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "globalValueSet",
+			"xmlName": "GlobalValueSet"
+		},
+		{
+			"directoryName": "globalValueSetTranslations",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "globalValueSetTranslation",
+			"xmlName": "GlobalValueSetTranslation"
+		},
+		{
+			"directoryName": "groups",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "group",
+			"xmlName": "Group"
+		},
+		{
+			"directoryName": "homePageComponents",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "homePageComponent",
+			"xmlName": "HomePageComponent"
+		},
+		{
+			"directoryName": "homePageLayouts",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "homePageLayout",
+			"xmlName": "HomePageLayout"
+		},
+		{
+			"directoryName": "installedPackages",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "installedPackage",
+			"xmlName": "InstalledPackage"
+		},
+		{
+			"directoryName": "moderation",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "keywords",
+			"xmlName": "KeywordList"
+		},
+		{
+			"directoryName": "layouts",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "layout",
+			"xmlName": "Layout"
+		},
+		{
+			"directoryName": "letterhead",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "letter",
+			"xmlName": "Letterhead"
+		},
+		{
+			"directoryName": "lwc",
+			"inFolder": false,
+			"metaFile": false,
+			"xmlName": "LightningComponentBundle"
+		},
+		{
+			"directoryName": "lightningExperienceThemes",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "lightningExperienceTheme",
+			"xmlName": "LightningExperienceTheme"
+		},
+		{
+			"directoryName": "messageChannels",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "messageChannel",
+			"xmlName": "LightningMessageChannel"
+		},
+		{
+			"directoryName": "liveChatAgentConfigs",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "liveChatAgentConfig",
+			"xmlName": "LiveChatAgentConfig"
+		},
+		{
+			"directoryName": "liveChatButtons",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "liveChatButton",
+			"xmlName": "LiveChatButton"
+		},
+		{
+			"directoryName": "liveChatDeployments",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "liveChatDeployment",
+			"xmlName": "LiveChatDeployment"
+		},
+		{
+			"directoryName": "liveChatSensitiveDataRule",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "liveChatSensitiveDataRule",
+			"xmlName": "LiveChatSensitiveDataRule"
+		},
+		{
+			"childXmlNames": [
+				"ManagedTopic"
+			],
+			"directoryName": "managedTopics",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "managedTopics",
+			"xmlName": "ManagedTopics"
+		},
+		{
+			"childXmlNames": [
+				"MatchingRule"
+			],
+			"directoryName": "matchingRules",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "matchingRule",
+			"xmlName": "MatchingRules"
+		},
+		{
+			"directoryName": "milestoneTypes",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "milestoneType",
+			"xmlName": "MilestoneType"
+		},
+		{
+			"directoryName": "moderation",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "rule",
+			"xmlName": "ModerationRule"
+		},
+		{
+			"directoryName": "namedCredentials",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "namedCredential",
+			"xmlName": "NamedCredential"
+		},
+		{
+			"directoryName": "networks",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "network",
+			"xmlName": "Network"
+		},
+		{
+			"directoryName": "pathAssistants",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "pathAssistant",
+			"xmlName": "PathAssistant"
+		},
+		{
+			"directoryName": "permissionsets",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "permissionset",
+			"xmlName": "PermissionSet"
+		},
+		{
+			"directoryName": "cachePartitions",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "cachePartition",
+			"xmlName": "PlatformCachePartition"
+		},
+		{
+			"directoryName": "portals",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "portal",
+			"xmlName": "Portal"
+		},
+		{
+			"directoryName": "postTemplates",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "postTemplate",
+			"xmlName": "PostTemplate"
+		},
+		{
+			"directoryName": "profiles",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "profile",
+			"xmlName": "Profile"
+		},
+		{
+			"directoryName": "profilePasswordPolicies",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "profilePasswordPolicy",
+			"xmlName": "ProfilePasswordPolicy"
+		},
+		{
+			"directoryName": "profileSessionSettings",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "profileSessionSetting",
+			"xmlName": "ProfileSessionSetting"
+		},
+		{
+			"directoryName": "prompts",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "prompt",
+			"xmlName": "Prompt"
+		},
+		{
+			"directoryName": "queues",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "queue",
+			"xmlName": "Queue"
+		},
+		{
+			"directoryName": "quickActions",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "quickAction",
+			"xmlName": "QuickAction"
+		},
+		{
+			"directoryName": "remoteSiteSettings",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "remoteSite",
+			"xmlName": "RemoteSiteSetting"
+		},
+		{
+			"directoryName": "reports",
+			"inFolder": true,
+			"metaFile": false,
+			"suffix": "report",
+			"xmlName": "Report"
+		},
+		{
+			"directoryName": "reportTypes",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "reportType",
+			"xmlName": "ReportType"
+		},
+		{
+			"directoryName": "roles",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "role",
+			"xmlName": "Role"
+		},
+		{
+			"directoryName": "samlssoconfigs",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "samlssoconfig",
+			"xmlName": "SamlSsoConfig"
+		},
+		{
+			"directoryName": "scontrols",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "scf",
+			"xmlName": "Scontrol"
+		},
+		{
+			"directoryName": "settings",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "settings",
+			"xmlName": "Settings"
+		},
+		{
+			"childXmlNames": [
+				"SharingOwnerRule",
+				"SharingCriteriaRule"
+			],
+			"directoryName": "sharingRules",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "sharingRules",
+			"xmlName": "SharingRules"
+		},
+		{
+			"directoryName": "sharingSets",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "sharingSet",
+			"xmlName": "SharingSet"
+		},
+		{
+			"directoryName": "siteDotComSites",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "site",
+			"xmlName": "SiteDotCom"
+		},
+		{
+			"directoryName": "skills",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "skill",
+			"xmlName": "Skill"
+		},
+		{
+			"directoryName": "standardValueSets",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "standardValueSet",
+			"xmlName": "StandardValueSet"
+		},
+		{
+			"directoryName": "standardValueSetTranslations",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "standardValueSetTranslation",
+			"xmlName": "StandardValueSetTranslation"
+		},
+		{
+			"directoryName": "staticresources",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "resource",
+			"xmlName": "StaticResource"
+		},
+		{
+			"directoryName": "synonymDictionaries",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "synonymDictionary",
+			"xmlName": "SynonymDictionary"
+		},
+		{
+			"directoryName": "transactionSecurityPolicies",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "transactionSecurityPolicy",
+			"xmlName": "TransactionSecurityPolicy"
+		},
+		{
+			"directoryName": "translations",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "translation",
+			"xmlName": "Translations"
+		},
+		{
+			"directoryName": "userCriteria",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "userCriteria",
+			"xmlName": "UserCriteria"
+		},
+		{
+			"directoryName": "wave",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "wapp",
+			"xmlName": "WaveApplication"
+		},
+		{
+			"directoryName": "wave",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "wdash",
+			"xmlName": "WaveDashboard"
+		},
+		{
+			"directoryName": "wave",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "wdf",
+			"xmlName": "WaveDataflow"
+		},
+		{
+			"directoryName": "wave",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "wds",
+			"xmlName": "WaveDataset"
+		},
+		{
+			"directoryName": "wave",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "wlens",
+			"xmlName": "WaveLens"
+		},
+		{
+			"directoryName": "wave",
+			"inFolder": false,
+			"metaFile": true,
+			"suffix": "wdpr",
+			"xmlName": "WaveRecipe"
+		},
+		{
+			"directoryName": "waveTemplates",
+			"inFolder": false,
+			"metaFile": false,
+			"xmlName": "WaveTemplateBundle"
+		},
+		{
+			"directoryName": "wave",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "xmd",
+			"xmlName": "WaveXmd"
+		},
+		{
+			"childXmlNames": [
+				"WorkflowFieldUpdate",
+				"WorkflowKnowledgePublish",
+				"WorkflowTask",
+				"WorkflowAlert",
+				"WorkflowSend",
+				"WorkflowOutboundMessage",
+				"WorkflowRule"
+			],
+			"directoryName": "workflows",
+			"inFolder": false,
+			"metaFile": false,
+			"suffix": "workflow",
+			"xmlName": "Workflow"
+		}
+	],
 	"organizationNamespace": "",
 	"partialSaveAllowed": true,
 	"testRequired": false

--- a/lib/metadata-container.js
+++ b/lib/metadata-container.js
@@ -263,7 +263,7 @@ MetadataContainer.prototype.completeMetadataWith = function(opts) {
 					var relativePaths = [];
 					if (stat.isDirectory()) {
 						// add all files in that directory in case of AuraDefinitionBundle or a WaveTemplate or LightningComponentBundle
-						if (filename.indexOf('aura') === 0 || filename.indexOf('waveTemplates') === 0 || filename.indexOf('lwc') === 0 ) {
+						if (filename.indexOf('aura') === 0 || filename.indexOf('waveTemplates') === 0 || filename.indexOf('lwc') === 0) {
 							var foo = listFilesInTree(realPath, filename);
 							relativePaths = flatten(foo);
 						}

--- a/lib/metadata-file-container.js
+++ b/lib/metadata-file-container.js
@@ -193,9 +193,15 @@ MetadataFileContainer.prototype.contentsWithoutChilds = function(includedChildCo
 		var parsed = new xmldoc.XmlDocument(this.contents);
 		var parentMetadata = '<' + parsed.name + ' xmlns="http://soap.sforce.com/2006/04/metadata">';
 		var tagIncludedChildNames = includedChildComponents ?
-			includedChildComponents.map(function(child) { return describeMetadataService.getType(child).tagName; }) : [];
-		var tagChildNames = childComponents.map(function(child) { return describeMetadataService.getType(child).tagName; })
-			.filter(function(child) { return !tagIncludedChildNames.includes(child); });
+			includedChildComponents.map(function(child) {
+				return describeMetadataService.getType(child).tagName;
+			}) : [];
+		var tagChildNames = childComponents.map(function(child) {
+				return describeMetadataService.getType(child).tagName;
+			})
+			.filter(function(child) {
+				return !tagIncludedChildNames.includes(child);
+			});
 		parsed.eachChild(function(child) {
 			var name = child.name;
 			if (!tagChildNames.includes(name)) {
@@ -216,7 +222,7 @@ MetadataFileContainer.prototype.contentsWithoutChilds = function(includedChildCo
 				compressed: false,
 				trimmed: false,
 				preserveWhitespace: !this.opts.ignoreWhitespace
-		}) + '\n');
+			}) + '\n');
 	}
 	return ret;
 }
@@ -229,8 +235,14 @@ MetadataFileContainer.prototype.writeContents = function() {
 
 MetadataFileContainer.prototype.updateContents = function(added, modified) {
 	var self = this;
-	var includedChildComponents = modified.manifestJSON.map(function(m) { return m.type; })
-			.concat(added.manifestJSON.map(function(m) { return m.type; })).filter(function(m) { return m !== undefined; });
+	var includedChildComponents = modified.manifestJSON.map(function(m) {
+			return m.type;
+		})
+		.concat(added.manifestJSON.map(function(m) {
+			return m.type;
+		})).filter(function(m) {
+			return m !== undefined;
+		});
 	var content = self.contentsWithoutChilds(includedChildComponents);
 	self.contents = Buffer.from(content.toString());
 	return self;

--- a/lib/metadata-file.js
+++ b/lib/metadata-file.js
@@ -116,7 +116,8 @@ MetadataFile.prototype.getComponent = function() {
 			result.fileName = path.join(metadataType.directoryName, metadataFile.basenameDirname());
 			result.fullName = metadataFile.basenameDirname();
 		}
-	}if (metadataType.directoryName === 'lwc') {
+	}
+	if (metadataType.directoryName === 'lwc') {
 		if (!metadataFile.extnameWithoutDot()) {
 			result.fileName = path.join(metadataType.directoryName, metadataFile.basename);
 			result.fullName = metadataFile.basename;
@@ -124,7 +125,7 @@ MetadataFile.prototype.getComponent = function() {
 			result.fileName = path.join(metadataType.directoryName, metadataFile.basenameDirname());
 			result.fullName = metadataFile.basenameDirname();
 		}
-	}else if (metadataType.directoryName === 'waveTemplates') {
+	} else if (metadataType.directoryName === 'waveTemplates') {
 		result.fileName = path.join(metadataType.directoryName, metadataFile.waveTemplateDirname());
 		result.fullName = metadataFile.waveTemplateDirname();
 	} else if (metadataType.inFolder) {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,0 +1,11 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true
+    }
+  ],
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "48.0"
+}


### PR DESCRIPTION
`force-dev-tool changeset create` should now support Metadata Types such as

- LeadConvertSettings
- MutingPermissionSet
- NavigationMenu
- NetworkBranding
- PermissionSetGroup

Note: This file is generated following https://github.com/amtrack/force-dev-tool/wiki/Contributing

Closes #250, closes #252 