### PR TITLE
#251: Validate that Component is not null before accessing it's attributes

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -53,7 +53,7 @@ Manifest.prototype.manifest = function() {
 
 Manifest.prototype.add = function(component) {
 	var self = this;
-	if (component != null && !_.findWhere(self.manifestJSON, {
+	if (component !== null && !_.findWhere(self.manifestJSON, {
 			type: component.type,
 			fullName: component.fullName
 		})) {

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -53,7 +53,7 @@ Manifest.prototype.manifest = function() {
 
 Manifest.prototype.add = function(component) {
 	var self = this;
-	if (!_.findWhere(self.manifestJSON, {
+	if (component != null && !_.findWhere(self.manifestJSON, {
 			type: component.type,
 			fullName: component.fullName
 		})) {


### PR DESCRIPTION
Since Salesforce new APIs are intriducing new metadata, some may not be still ready on the CLI pluging when generating the delta packages. If that is the case, the component is null and trying to access its attributes is actually breaking the whole process.

This PR is fixing the error #251 